### PR TITLE
Use hovercard to reduce the pull request review status based on GitHub's algorithm, rather than trying to figure it out ourselves.

### DIFF
--- a/code.js
+++ b/code.js
@@ -117,11 +117,13 @@ function refreshStatus(callback) {
                   login
                   url
                 }
-                approvedReviews: reviews(first: 10, states: APPROVED) {
-                  totalCount
-                }
-                changesRequestedReviews: reviews(first: 10, states: CHANGES_REQUESTED) {
-                  totalCount
+                # Simplest way to get reviewed state is with the hovercard...
+                hovercard(includeNotificationContexts:false) {
+                  contexts {
+                    message
+                    octicon
+                    __typename
+                  }
                 }
                 number
                 url
@@ -178,11 +180,13 @@ function refreshStatus(callback) {
                       login
                       url
                     }
-                    approvedReviews: reviews(first: 10, states: APPROVED) {
-                      totalCount
-                    }
-                    changesRequestedReviews: reviews(first: 10, states: CHANGES_REQUESTED) {
-                      totalCount
+                    # Simplest way to get reviewed state is with the hovercard...
+                    hovercard(includeNotificationContexts:false) {
+                      contexts {
+                        message
+                        octicon
+                        __typename
+                      }
                     }
                     url
                   }

--- a/public/src/app/pull-request/pull-request.component.ts
+++ b/public/src/app/pull-request/pull-request.component.ts
@@ -25,11 +25,11 @@ export class PullRequestComponent implements OnInit {
   }
 
   pullStatus() {
-    if(this.pull.pull.node.changesRequestedReviews.totalCount) {
-      return "status-changes-requested";
-    }
-    if(this.pull.pull.node.approvedReviews.totalCount) {
-      return "status-approved";
+    let state: string = this.pull.pull.node.hovercard.contexts.reduce((a, c) => a || (c.__typename == "ReviewStatusHovercardContext" ? c.octicon : null), null);
+    switch(state) {
+      case "comment":         return "status-pending";
+      case "check":           return "status-approved";
+      case "request-changes": return "status-changes-requested";
     }
 
     return "status-pending";


### PR DESCRIPTION
The pullRequest graph node supports returning the current code review status in the "hovercard" member. It's a bit abstracted rather than what we'd like ideally ("reviewStatus") but it's still possible to pull the value out with a little bit of effort.

Previously, the review status was not correct for PRs that had had changes requested and then those changes approved; we could have got that by scanning all the reviews and building up the aggregate latest status but this is much simpler.