### PR TITLE
fix: draft PRs and status now consistent

### DIFF
--- a/code.js
+++ b/code.js
@@ -100,7 +100,8 @@ function refreshStatus(callback) {
     httppost('api.github.com', '/graphql',
       {
         Authorization: ` Bearer ${github_token}`,
-        Accept: 'application/vnd.github.antiope-preview'
+        Accept: 'application/vnd.github.antiope-preview',
+        Accept: 'application/vnd.github.shadow-cat-preview+json'
       },
 
       // Lists all open pull requests in keyman repos
@@ -121,7 +122,8 @@ function refreshStatus(callback) {
     httppost('api.github.com', '/graphql',
       {
         Authorization: ` Bearer ${github_token}`,
-        Accept: 'application/vnd.github.antiope-preview'
+        Accept: 'application/vnd.github.antiope-preview',
+        Accept: 'application/vnd.github.shadow-cat-preview+json'
       },
 
       // Gather the contributions for each recent user

--- a/github-status.js
+++ b/github-status.js
@@ -54,19 +54,32 @@ exports.queryString = function() { return `
           milestone {
             title
           }
+
+          isDraft # requires application/vnd.github.shadow-cat-preview+json
+
           author {
             avatarUrl
             login
             url
           }
+
           # Simplest way to get reviewed state is with the hovercard...
-          hovercard(includeNotificationContexts:false) {
-            contexts {
-              message
-              octicon
-              __typename
+          reviews(last:100) {
+            nodes {
+              author { login }
+              updatedAt
+              state
             }
           }
+
+          #hovercard(includeNotificationContexts:false) {
+          #  contexts {
+          #    message
+          #    octicon
+          #    __typename
+          #  }
+          #}
+
           number
           url
           commits(last: 1) {
@@ -114,6 +127,7 @@ exports.queryString = function() { return `
             node {
               title
               number
+              isDraft # requires application/vnd.github.shadow-cat-preview+json
               milestone {
                 title
               }
@@ -122,14 +136,24 @@ exports.queryString = function() { return `
                 login
                 url
               }
-              # Simplest way to get reviewed state is with the hovercard...
-              hovercard(includeNotificationContexts:false) {
-                contexts {
-                  message
-                  octicon
-                  __typename
+
+              reviews(last:100) {
+                nodes {
+                  author { login }
+                  updatedAt
+                  state
                 }
               }
+
+              # Simplest way to get reviewed state is with the hovercard...
+              #hovercard(includeNotificationContexts:false) {
+              #  contexts {
+              #    message
+              #    octicon
+              #    __typename
+              #  }
+              #}
+
               url
             }
           }

--- a/github-status.js
+++ b/github-status.js
@@ -63,7 +63,6 @@ exports.queryString = function() { return `
             url
           }
 
-          # Simplest way to get reviewed state is with the hovercard...
           reviews(last:100) {
             nodes {
               author { login }
@@ -71,14 +70,6 @@ exports.queryString = function() { return `
               state
             }
           }
-
-          #hovercard(includeNotificationContexts:false) {
-          #  contexts {
-          #    message
-          #    octicon
-          #    __typename
-          #  }
-          #}
 
           number
           url
@@ -144,15 +135,6 @@ exports.queryString = function() { return `
                   state
                 }
               }
-
-              # Simplest way to get reviewed state is with the hovercard...
-              #hovercard(includeNotificationContexts:false) {
-              #  contexts {
-              #    message
-              #    octicon
-              #    __typename
-              #  }
-              #}
 
               url
             }

--- a/public/src/app/app.component.css
+++ b/public/src/app/app.component.css
@@ -154,10 +154,7 @@ td, th {
 }
 
 .tier-release-date {
-  xpadding: 4px 4px 0;
   text-align: center;
-  xmargin: 0 4px;
-  xwidth: 112px;
 }
 
 .tier-release-version {

--- a/public/src/app/app.component.css
+++ b/public/src/app/app.component.css
@@ -149,14 +149,15 @@ td, th {
 }
 
 .tier-release {
-  float: left;
+  display: inline-block;
+  vertical-align: middle;
 }
 
 .tier-release-date {
-  padding: 4px 4px 0;
+  xpadding: 4px 4px 0;
   text-align: center;
-  margin: 0 4px;
-  width: 112px;
+  xmargin: 0 4px;
+  xwidth: 112px;
 }
 
 .tier-release-version {
@@ -167,9 +168,15 @@ td, th {
 }
 
 .tier-build-state {
-  float: left;
-  margin-left: 8px;
+  display: inline-block;
+  margin-left: 0px;
+  vertical-align: middle;
   width: 120px;
+}
+
+tbody th,
+td#tier-stable, td#tier-beta, td#tier-alpha {
+  white-space: nowrap;
 }
 
 thead th.tier {

--- a/public/src/app/platforms.ts
+++ b/public/src/app/platforms.ts
@@ -37,7 +37,7 @@ export const platforms = {
   },
   'developer': {
     id:'developer',
-    name:'Developer Tools',
+    name:'Developer',
     configs:{"alpha": "Keyman_Build", "beta": "KeymanDesktop_Beta", "stable": "KeymanDesktop_Stable", prs: "KeymanDesktop_TestPullRequests"},
     context: "Test: Pull Requests (Keyman Desktop and Keyman Developer)"
   },

--- a/public/src/app/pull-request/pull-request.component.css
+++ b/public/src/app/pull-request/pull-request.component.css
@@ -3,6 +3,7 @@
   border-radius: 4px;
   display: inline-block;
   background: #c0c0c0;
+  box-shadow: 3px 3px rgba(40,40,40,0.2);
 }
 
 .label a.author img.avatar-32 {
@@ -41,6 +42,10 @@
 
 /* Future PRs */
 
+.label.status-draft {
+  opacity: 0.5;
+}
+
 .future {
   opacity: 0.3;
 }
@@ -56,7 +61,7 @@
 .label.status-approved::after {
   content: '✔️';
   alt: 'Approved';
-  font-size: 0.5rem;
+  font-size: 0.75rem;
   display: inline-block;
   color: black;
 }
@@ -64,17 +69,24 @@
 .label.status-pending::after {
   content:'🟡';
   alt: 'Pending';
-  font-size: 0.5rem;
+  font-size: 0.75rem;
   color: black;
 }
 
 .label.status-changes-requested::after {
   content:'❌';
   alt: 'Changes Requested';
-  font-size: 0.5rem;
+  font-size: 0.75rem;
   color: black;
 }
 
+.label.status-draft::after {
+  content:'🚧';
+  alt: 'In Draft';
+  padding-right: 4px;
+  font-size: 0.75rem;
+  color: black;
+}
 
 .label a.pull {
   padding: 0px 6px;

--- a/public/src/app/pull-request/pull-request.component.ts
+++ b/public/src/app/pull-request/pull-request.component.ts
@@ -25,6 +25,28 @@ export class PullRequestComponent implements OnInit {
   }
 
   pullStatus() {
+    let authors = {};
+
+    if(this.pull.pull.node.isDraft) return 'status-draft';
+
+    this.pull.pull.node.reviews.nodes.forEach(review => {
+      if(!authors[review.author.login]) authors[review.author.login] = {reviews:[]};
+      authors[review.author.login].reviews.push(review);
+    });
+
+    Object.entries(authors).forEach(entry => {
+      entry[1].state = entry[1].reviews.reduce((a, c) => c.state == 'APPROVED' || c.state == 'CHANGES_REQUESTED' ? c.state : a, 'PENDING');
+    });
+
+    return Object.entries(authors).reduce(
+      (a, c) =>
+        c[1].state == 'CHANGES_REQUESTED' || a == 'status-changes-requested' ? 'status-changes-requested' :
+        c[1].state == 'APPROVED' || a == 'status-approved' ? 'status-approved' : 'status-pending',
+      'status-pending' // Initial value
+    );
+
+    /*console.log(authors);
+
     let state: string = this.pull.pull.node.hovercard.contexts.reduce((a, c) => a || (c.__typename == "ReviewStatusHovercardContext" ? c.octicon : null), null);
     switch(state) {
       case "comment":         return "status-pending";
@@ -32,7 +54,7 @@ export class PullRequestComponent implements OnInit {
       case "request-changes": return "status-changes-requested";
     }
 
-    return "status-pending";
+    return "status-pending";*/
   }
 
 }

--- a/public/src/app/pull-request/pull-request.component.ts
+++ b/public/src/app/pull-request/pull-request.component.ts
@@ -35,26 +35,15 @@ export class PullRequestComponent implements OnInit {
     });
 
     Object.entries(authors).forEach(entry => {
-      entry[1].state = entry[1].reviews.reduce((a, c) => c.state == 'APPROVED' || c.state == 'CHANGES_REQUESTED' ? c.state : a, 'PENDING');
+      (entry[1] as any).state = (entry[1] as any).reviews.reduce((a, c) => c.state == 'APPROVED' || c.state == 'CHANGES_REQUESTED' ? c.state : a, 'PENDING');
     });
 
     return Object.entries(authors).reduce(
       (a, c) =>
-        c[1].state == 'CHANGES_REQUESTED' || a == 'status-changes-requested' ? 'status-changes-requested' :
-        c[1].state == 'APPROVED' || a == 'status-approved' ? 'status-approved' : 'status-pending',
+        (c[1] as any).state == 'CHANGES_REQUESTED' || a == 'status-changes-requested' ? 'status-changes-requested' :
+        (c[1] as any).state == 'APPROVED' || a == 'status-approved' ? 'status-approved' : 'status-pending',
       'status-pending' // Initial value
     );
-
-    /*console.log(authors);
-
-    let state: string = this.pull.pull.node.hovercard.contexts.reduce((a, c) => a || (c.__typename == "ReviewStatusHovercardContext" ? c.octicon : null), null);
-    switch(state) {
-      case "comment":         return "status-pending";
-      case "check":           return "status-approved";
-      case "request-changes": return "status-changes-requested";
-    }
-
-    return "status-pending";*/
   }
 
 }


### PR DESCRIPTION
Draft PRs are shown slightly faded and with a construction barrier.
Status was not always consistently computed but now works from the
list of reviews and should be okay if <100 reviews/comments on a PR.

While I was at it, I tweaked the layout to make more elements fit on
the screen without compromising overall structure.