### PR TITLE
change: label.error color from white to orange

### DIFF
--- a/public/src/app/sentry/sentry.component.css
+++ b/public/src/app/sentry/sentry.component.css
@@ -25,7 +25,7 @@
 }
 
 .label.error a {
-  color: white;
+  color: orange;
 }
 
 .label a {


### PR DESCRIPTION
With the current white labels, I had a hard time seeing the Sentry error count.

This changes it to orange

![sentry errors](https://user-images.githubusercontent.com/7358010/76045674-6903af80-5f90-11ea-859e-55ca7cb3f37a.PNG)
