### PR TITLE
feat: formatting

### DIFF
--- a/public/src/app/app.component.css
+++ b/public/src/app/app.component.css
@@ -97,33 +97,48 @@ td, th {
 
 .tier-release-date {
   text-align: center;
+  font-size: 12px;
 }
 
-.tier-release-version {
+.tier-release-version a {
+  display: inline-block;
   text-align: center;
-  font-size: 12px;
-  color: #909090;
-  width: 120px;
+  text-decoration: underline;
+  font-size: 19px;
+  font-weight: 200;
+  color: white;
+  background-color: #44cc11;
+  width: 30px;
+  border-radius: 0 4px 4px 0;
+  border-left: 1px solid white;
+  min-height: 32px;
+  max-height: 32px;
+  height: 32px;
 }
 
 .tier-release-version.tier-release-version-error a {
   background-color: red;
-  padding: 0 2px;
   color: white;
-  border-radius: 3px;
 }
 
 .tier-release-version.tier-release-version-pending a {
   background-color: rgb(240,240,100);
-  padding: 0 2px;
-  border-radius: 3px;
+  color: black;
+}
+
+.tier-build-state a.label {
+  margin-right: 0;
+  border-radius: 4px 0 0 4px;
+  min-height: 32px;
+  max-height: 32px;
+  height: 32px;
+  padding-right: 8px;
 }
 
 .tier-build-state {
   display: inline-block;
   margin-left: 0px;
   vertical-align: middle;
-  width: 120px;
 }
 
 tbody th,

--- a/public/src/app/app.component.html
+++ b/public/src/app/app.component.html
@@ -93,50 +93,50 @@
 
         <td class="tier" id="tier-stable">
           <div class="tier-container" *ngIf="platform.value.id != 'common'">
-            <div class="tier-release">
-              <div class="tier-release-date">
-                {{releaseDate(platform.value.id,'stable')}}
-              </div>
-              <div class="tier-release-version {{downloadClass(platform.value.id,'stable')}}">
-                <a href="{{status?.keyman[platform.value.id].stable.downloadUrl}}" target="_blank">{{status?.keyman[platform.value.id].stable.version}}</a>
-              </div>
-            </div>
             <div class="tier-build-state" title="{{statusTip(platform.value.id,'stable')}}">
               <a class="label {{statusClass(platform.value.id,'stable')}}" href="{{statusLink(platform.value.id,'stable')}}" target="_blank">{{statusText(platform.value.id,'stable')}}</a>
             </div>
-          </div>
+            <div class="tier-release">
+              <div class="tier-release-version {{downloadClass(platform.value.id,'stable')}}">
+                <a href="{{status?.keyman[platform.value.id].stable.downloadUrl}}" target="_blank" title="Version on download.keyman.com: {{status?.keyman[platform.value.id].stable.version}}">v</a>
+              </div>
+            </div>
+            <div class="tier-release-date">
+              {{releaseDate(platform.value.id,'stable')}}
+            </div>
+        </div>
         </td>
 
         <td class="tier" id="tier-beta">
           <div class="tier-container" *ngIf="platform.value.id != 'common'">
-            <div class="tier-release">
-              <div class="tier-release-date">
-                {{releaseDate(platform.value.id,'beta')}}
-              </div>
-              <div class="tier-release-version {{downloadClass(platform.value.id,'beta')}}">
-                <a href="{{status?.keyman[platform.value.id].beta.downloadUrl}}" target="_blank">{{status?.keyman[platform.value.id].beta.version}}</a>
-              </div>
-            </div>
             <div class="tier-build-state" title="{{statusTip(platform.value.id,'beta')}}">
               <a class="label {{statusClass(platform.value.id,'beta')}}" href="{{statusLink(platform.value.id,'beta')}}" target="_blank">{{statusText(platform.value.id,'beta')}}</a>
             </div>
-          </div>
+            <div class="tier-release">
+              <div class="tier-release-version {{downloadClass(platform.value.id,'beta')}}">
+                <a href="{{status?.keyman[platform.value.id].beta.downloadUrl}}" target="_blank" title="Version on download.keyman.com: {{status?.keyman[platform.value.id].beta.version}}">v</a>
+              </div>
+            </div>
+            <div class="tier-release-date">
+              {{releaseDate(platform.value.id,'beta')}}
+            </div>
+        </div>
         </td>
 
         <td class="tier" id="tier-alpha">
           <div class="tier-container" *ngIf="platform.value.id != 'common'">
-            <div class="tier-release">
-              <div class="tier-release-date">
-                {{releaseDate(platform.value.id,'alpha')}}
-              </div>
-              <div class="tier-release-version {{downloadClass(platform.value.id,'alpha')}}">
-                <a href="{{status?.keyman[platform.value.id].alpha.downloadUrl}}" target="_blank">{{status?.keyman[platform.value.id].alpha.version}}</a>
-              </div>
-            </div>
             <div class="tier-build-state" title="{{statusTip(platform.value.id,'alpha')}}">
               <a class="label {{statusClass(platform.value.id,'alpha')}}" href="{{statusLink(platform.value.id,'alpha')}}" target="_blank">{{statusText(platform.value.id,'alpha')}}</a>
             </div>
-          </div>
+            <div class="tier-release">
+              <div class="tier-release-version {{downloadClass(platform.value.id,'alpha')}}">
+                <a href="{{status?.keyman[platform.value.id].alpha.downloadUrl}}" target="_blank" title="Version on download.keyman.com: {{status?.keyman[platform.value.id].alpha.version}}">v</a>
+              </div>
+            </div>
+            <div class="tier-release-date">
+              {{releaseDate(platform.value.id,'alpha')}}
+            </div>
+        </div>
         </td>
 
         <td class="sentry-events">
@@ -158,7 +158,7 @@
 
     </tbody>
   </table>
-  <table id="sites-and-relatives" class="table table-striped table-bordered">
+  <table id="sites-and-relatives" class="table table-striped table-bordered table-sm">
     <tbody>
       <tr class='tr-site'>
         <th class='th-keyboards'><a href="https://github.com/keymanapp/keyboards" target="_blank">⌨ keyboards</a></th>

--- a/public/src/app/app.component.ts
+++ b/public/src/app/app.component.ts
@@ -297,7 +297,15 @@ export class AppComponent {
           case this.phase.title: site.milestones[0].count++; break;
           case "Future": site.milestones[1].count++; break;
           case "Waiting-external": site.milestones[2].count++; break;
-          default: site.milestones[3].count++; break;
+          default:
+            let m = site.milestones.find(element => {return element.title == issue.node.milestone.title});
+            if(!m) {
+              m = { id: 'future', title: issue.node.milestone.title, count: 0};
+              site.milestones.push(m);
+            }
+            m.count++;
+            break;
+
         }
       });
     });


### PR DESCRIPTION
Reduce the width of the tier columns with
a download button rather than repeated version,
add all sprint milestones in site view, and
condense the site table so it fits on screen
more easily.