### PR TITLE
Revert "change: label.error color from white to orange"

### DIFF
--- a/public/src/app/sentry/sentry.component.css
+++ b/public/src/app/sentry/sentry.component.css
@@ -36,3 +36,7 @@
   display: inline-block;
   vertical-align: middle;
 }
+
+.sentry-container {
+  white-space: nowrap;
+}

--- a/public/src/app/sentry/sentry.component.css
+++ b/public/src/app/sentry/sentry.component.css
@@ -25,7 +25,7 @@
 }
 
 .label.error a {
-  color: orange;
+  color: white;
 }
 
 .label a {


### PR DESCRIPTION
Reverts keymanapp/status.keyman.com#34

![image](https://user-images.githubusercontent.com/4498365/76952581-6bd3ac80-6961-11ea-911f-d57e622d9167.png)

I think I will fix the wrapping to resolve the colour issue properly!