### PR TITLE
feat: status checks for sites

### DIFF
--- a/code.js
+++ b/code.js
@@ -104,8 +104,7 @@ function refreshStatus(sprint, callback) {
     httppost('api.github.com', '/graphql',
       {
         Authorization: ` Bearer ${github_token}`,
-        Accept: 'application/vnd.github.antiope-preview',
-        Accept: 'application/vnd.github.shadow-cat-preview+json'
+        Accept: 'application/vnd.github.antiope-preview+json, application/vnd.github.shadow-cat-preview+json'
       },
 
       // Lists all open pull requests in keyman repos
@@ -122,6 +121,8 @@ function refreshStatus(sprint, callback) {
   ]).then(data => {
     // Get the current sprint from the GitHub data
     // We actually get data from the Saturday before the 'official' sprint start
+
+    //console.log(data);
 
     let githubPullsData = JSON.parse(data[3]);
     const phase = currentSprint.getCurrentSprint(githubPullsData.data);
@@ -153,8 +154,7 @@ function refreshStatus(sprint, callback) {
       httppost('api.github.com', '/graphql',
         {
           Authorization: ` Bearer ${github_token}`,
-          Accept: 'application/vnd.github.antiope-preview',
-          Accept: 'application/vnd.github.shadow-cat-preview+json'
+          Accept: 'application/vnd.github.antiope-preview, application/vnd.github.shadow-cat-preview+json'
         },
         // Gather the contributions for each recent user
 

--- a/github-status.js
+++ b/github-status.js
@@ -193,6 +193,19 @@ exports.queryString = function(sprint) {
                 url
               }
 
+              commits(last: 1) {
+                nodes {
+                  commit {
+                    checkSuites(last:1) {
+                      nodes {
+                        conclusion
+                        status
+                      }
+                    }
+                  }
+                }
+              }
+
               reviews(last:100) {
                 nodes {
                   author { login }

--- a/public/src/app/app.component.html
+++ b/public/src/app/app.component.html
@@ -16,9 +16,6 @@
           <span class="navbar-new-pulls">
             <span *ngFor="let pull of unlabeledPulls">
               <app-pull-request [class]="'failure'" [pull]="pull"></app-pull-request>
-              <!--
-                <a href="{{pull.pull.node.url}}" class="label {{pullClass(pull)}}" title="{{pull.pull.node.title}}: {{pull.state?.description}}" target="_blank">{{pull.pull.node.number}}</a>
-              -->
             </span>
           </span>
           <span class="navbar-contributions" *ngIf="showContributions">
@@ -194,7 +191,7 @@
         <td class='crashes'></td>-->
         <td class='pulls'>
           <span *ngFor="let pull of site.value.pulls">
-            <app-pull-request [class]="'missing'" [pull]="pull"></app-pull-request>
+            <app-pull-request [class]="" [pull]="pull"></app-pull-request>
           </span>
         </td>
         </ng-container>

--- a/public/src/app/app.component.ts
+++ b/public/src/app/app.component.ts
@@ -140,17 +140,6 @@ export class AppComponent {
     return files[items[0]].date;
   }
 
-  pullClass(pull): string {
-    //console.log(pull);
-    if(!pull.state) return 'missing';
-    switch(pull.state.state) {
-      case 'SUCCESS': return 'success';
-      case 'PENDING': return 'pending';
-      default: return 'failure';
-    }
-    //return pull.state ? pull.state.state == 'SUCCESS' ? 'success' : 'failure' : 'missing';
-  }
-
   transformPlatformStatusData() {
     this.labeledPulls = [];
 

--- a/public/src/app/pull-request/pull-request.component.ts
+++ b/public/src/app/pull-request/pull-request.component.ts
@@ -16,6 +16,28 @@ export class PullRequestComponent implements OnInit {
 
   pullClass() {
     let base = this.pull.pull.node.milestone ? this.pull.pull.node.milestone.title == 'Future' ? 'future ' : '' : '';
+    //if(this.pull.pull.node.commits?.nodes[0]?.commit?.checkSuites?.nodes[0]?.status == 'COMPLETED') {
+    //One day, with optional chaining (nearly here)
+    if(this.pull.pull.node.commits && this.pull.pull.node.commits.nodes && this.pull.pull.node.commits.nodes.length && this.pull.pull.node.commits.nodes[0].commit &&
+        this.pull.pull.node.commits.nodes[0].commit.checkSuites &&
+        this.pull.pull.node.commits.nodes[0].commit.checkSuites.nodes.length) {
+      if(this.pull.pull.node.commits.nodes[0].commit.checkSuites.nodes[0].status == 'COMPLETED') {
+        switch(this.pull.pull.node.commits.nodes[0].commit.checkSuites.nodes[0].conclusion) {
+          case 'SUCCESS':   return base+'success';
+          case 'ACTION_REQUIRED':
+          case 'TIMED_OUT':
+          case 'FAILURE':   return base+'failure';
+          case 'CANCELLED':
+          case 'SKIPPED':
+          case 'STALE':
+          case 'NEUTRAL':
+          default: return base+'missing'; // various other states
+        }
+      } else {
+        //IN_PROGRESS, QUEUED, REQUESTED
+        return base+'pending';
+      }
+    }
     if(!this.pull.state) return base+'missing';
     switch(this.pull.state.state) {
       case 'SUCCESS': return base+'success';


### PR DESCRIPTION
Now that we are starting to use GH actions for sites, it is helpful to be reporting on the status of each pull request. This bumps the rate cost for the status query from 35 to 60. Together with the current contributions query cost of 3, we should still be well within 5000/hour (we refresh once per minute = 3780).