### PR TITLE
feat: show issue lists

### DIFF
--- a/code.js
+++ b/code.js
@@ -15,7 +15,7 @@ const teamcity_token=process.env['KEYMANSTATUS_TEAMCITY_TOKEN'];
 const github_token=process.env['KEYMANSTATUS_GITHUB_TOKEN'];
 const sentry_token=process.env['KEYMANSTATUS_SENTRY_TOKEN'];
 
-const REFRESH_INTERVAL = 60000; //msec
+const REFRESH_INTERVAL = isProduction ? 60000 : 60000 * 60; //msec
 let lastRefreshTime = 0;
 
 let cachedData = {};

--- a/github-status.js
+++ b/github-status.js
@@ -130,6 +130,9 @@ exports.queryString = function(sprint) {
 
           isDraft # requires application/vnd.github.shadow-cat-preview+json
 
+          headRefName
+          baseRefName
+
           author {
             avatarUrl
             login
@@ -178,11 +181,18 @@ exports.queryString = function(sprint) {
         name
         issuesByMilestone: issues(first: 100, filterBy: {states: [OPEN]}) {
           totalCount
-          edges {
-            node {
-              milestone {
-                title
-              }
+          nodes {
+            author {
+              login
+              avatarUrl
+              url
+            }
+            title
+            number
+            url
+
+            milestone {
+              title
             }
           }
         }
@@ -192,6 +202,8 @@ exports.queryString = function(sprint) {
               title
               number
               isDraft # requires application/vnd.github.shadow-cat-preview+json
+              headRefName
+              baseRefName
               milestone {
                 title
               }

--- a/github-status.js
+++ b/github-status.js
@@ -80,11 +80,19 @@ exports.queryString = function(sprint) {
           name
           openIssues: issues(first: 100, filterBy: {states: [OPEN]}) {
             totalCount
-            edges {
-              node {
-                milestone {
-                  title
-                }
+            nodes {
+
+              author {
+                login
+                avatarUrl
+                url
+              }
+              title
+              number
+              url
+
+              milestone {
+                title
               }
             }
           }

--- a/public/src/app/app.component.css
+++ b/public/src/app/app.component.css
@@ -284,10 +284,10 @@ table#sites-and-relatives {
 app-issue-list {
   display: none;
   position: absolute;
-  left: 4px;
-  bottom: -6px;
   max-width: 400px;
   width: auto;
+  z-index: 10;
+  text-align: left;
 }
 
 .navbar-new-issues:hover app-issue-list,
@@ -295,7 +295,17 @@ app-issue-list {
   display: block;
 }
 
-.issue-box app-issue-list {
-  bottom: -2px;
+.tr-platform .issue-box app-issue-list {
+  top: 24px;
   left: 2px;
+}
+
+.tr-site .issue-box app-issue-list {
+  bottom: 22px;
+  left: 2px;
+}
+
+.navbar-new-issues app-issue-list {
+  left: 4px;
+  top: 28px;
 }

--- a/public/src/app/app.component.css
+++ b/public/src/app/app.component.css
@@ -276,7 +276,8 @@ table#sites-and-relatives {
 
 /* Issue List */
 
-.navbar-new-issues {
+.navbar-new-issues,
+.issue-box {
   position: relative;
 }
 
@@ -289,5 +290,12 @@ app-issue-list {
   width: auto;
 }
 
-.navbar-new-issues:hover app-issue-list { display: block; }
+.navbar-new-issues:hover app-issue-list,
+.issue-box:hover app-issue-list {
+  display: block;
+}
 
+.issue-box app-issue-list {
+  bottom: -2px;
+  left: 2px;
+}

--- a/public/src/app/app.component.html
+++ b/public/src/app/app.component.html
@@ -156,7 +156,7 @@
           <ng-container *ngFor="let milestone of platform.value.milestones">
             <span class="issue-box">
               <app-count-box [repo]="'keyman'" [title]="milestone.title" [count]="milestone.count" [label]="platform.value.id+'/'" [class]="'milestone-'+milestone.id"></app-count-box>
-              <app-issue-list [issues]="milestone?.nodes"></app-issue-list>
+              <app-issue-list *ngIf="milestone.title != 'Future'" [issues]="milestone?.nodes"></app-issue-list>
             </span>
           </ng-container>
         </td>

--- a/public/src/app/app.component.html
+++ b/public/src/app/app.component.html
@@ -154,7 +154,10 @@
           </a>
 
           <ng-container *ngFor="let milestone of platform.value.milestones">
-            <app-count-box [repo]="'keyman'" [title]="milestone.title" [count]="milestone.count" [label]="platform.value.id+'/'" [class]="'milestone-'+milestone.id"></app-count-box>
+            <span class="issue-box">
+              <app-count-box [repo]="'keyman'" [title]="milestone.title" [count]="milestone.count" [label]="platform.value.id+'/'" [class]="'milestone-'+milestone.id"></app-count-box>
+              <app-issue-list [issues]="milestone?.nodes"></app-issue-list>
+            </span>
           </ng-container>
         </td>
 

--- a/public/src/app/app.component.html
+++ b/public/src/app/app.component.html
@@ -213,7 +213,10 @@
           <td class='issues'>
 
             <ng-container *ngFor="let milestone of site.value.milestones">
-              <app-count-box [repo]="site.key" [title]="milestone.title" [count]="milestone.count" [class]="'milestone-'+milestone.id"></app-count-box>
+              <span class="issue-box">
+                <app-count-box [repo]="site.key" [title]="milestone.title" [count]="milestone.count" [class]="'milestone-'+milestone.id"></app-count-box>
+                <app-issue-list *ngIf="milestone.title != 'Future'" [issues]="milestone?.nodes"></app-issue-list>
+              </span>
             </ng-container>
           </td>
         </ng-container>

--- a/public/src/app/app.component.ts
+++ b/public/src/app/app.component.ts
@@ -17,7 +17,7 @@ export class AppComponent {
   timer: any;
   title = 'Keyman Status';
 
-  TIMER_INTERVAL = 60000; //msec
+  TIMER_INTERVAL = 60000 * 60; //msec
   platforms: PlatformSpec[] = JSON.parse(JSON.stringify(platforms)); // makes a copy of the constant platform data for this component
   sites = Object.assign({}, ...sites.map(v => ({[v]: {id: /^([^.]+)/.exec(v)[0], pulls:[]}}))); // make an object map of 'url.com': {pulls:[]}
   unlabeledPulls = [];
@@ -251,31 +251,36 @@ export class AppComponent {
       return (parseInt(a0[1], 10) - parseInt(b0[1], 10))*100 + (parseInt(a0[2], 10) - parseInt(b0[2], 10));
     };
 
+    // TODO: split search against future and current milestones (future milestone shows only count; current milestone shows more detail)
     // For each platform, fill in the milestone counts
     this.status.github.data.repository.issuesByLabelAndMilestone.edges.forEach(label => {
       let platform = this.getPlatform(label.node.name.substring(0,label.node.name.length-1));
       if(!platform) return;
       platform.totalIssueCount = label.node.openIssues.totalCount;
       platform.milestones = [
-        { id: 'current', title: this.phase.title, count: 0 },
-        { id: 'future', title: "Future", count: 0 },
-        { id: 'waiting', title: "Waiting-external", count: 0 },
-        { id: 'other', title: "Other", count: 0 }
+        { id: 'current', title: this.phase.title, count: 0, nodes: [] },
+        { id: 'future', title: "Future", count: 0, nodes: [] },
+        { id: 'waiting', title: "Waiting-external", count: 0, nodes: [] },
+        { id: 'other', title: "Other", count: 0, nodes: [] }
       ];
-      label.node.openIssues.edges.forEach(issue => {
-        if(!issue.node.milestone) platform.milestones[3].count++;
-        else switch(issue.node.milestone.title) {
-          case this.phase.title: platform.milestones[0].count++; break;
-          case "Future": platform.milestones[1].count++; break;
-          case "Waiting-external": platform.milestones[2].count++; break;
+      label.node.openIssues.nodes.forEach(issue => {
+        let m = null;
+        if(!issue.milestone) m = platform.milestones[3];
+        else switch(issue.milestone.title) {
+          case this.phase.title: m = platform.milestones[0]; break;
+          case "Future": m = platform.milestones[1]; break;
+          case "Waiting-external": m = platform.milestones[2]; break;
           default:
-            let m = platform.milestones.find(element => {return element.title == issue.node.milestone.title});
+            m = platform.milestones.find(element => {return element.title == issue.milestone.title});
             if(!m) {
-              m = { id: 'future', title: issue.node.milestone.title, count: 0};
+              m = { id: 'future', title: issue.milestone.title, count: 0, nodes: []};
               platform.milestones.push(m);
             }
-            m.count++;
             break;
+        }
+        if(m) {
+          m.count++;
+          m.nodes.push(issue);
         }
       });
 

--- a/public/src/app/issue-list/issue-list.component.css
+++ b/public/src/app/issue-list/issue-list.component.css
@@ -5,7 +5,7 @@
   border: solid 1px #4c4c30;
   border-radius: 0 0 4px 4px;
   box-shadow: 2px 2px 4px rgba(0,0,0,0.5);
-  padding: 8px;
+  padding: 0 3px 3px 3px;
   width: max-content;
   max-width: 720px;
 }

--- a/public/src/app/issue-list/issue-list.component.css
+++ b/public/src/app/issue-list/issue-list.component.css
@@ -1,6 +1,4 @@
 .issue-list {
-  position: absolute;
-  z-index: 10;
   background: #fcfffc;
   border: solid 1px #4c4c30;
   border-radius: 0 0 4px 4px;

--- a/public/src/app/issue-list/issue-list.component.css
+++ b/public/src/app/issue-list/issue-list.component.css
@@ -23,12 +23,20 @@ li {
 
 .label {
   display: block;
-  text-indent: -12px;
-  margin-left: 24px;
+  text-indent: 0;
+  margin-left: 4px;
 }
 
 .issue {
-  padding-left: 2px;
+  display: inline-block;
+  height: 22px;
+  padding: 4px 8px 2px 4px;
+  margin-top: 4px;
+}
+
+.issue:hover {
+  background: #c0ffff;
+  border-radius: 3px 3px 0 0;
 }
 
 .label a,
@@ -47,4 +55,7 @@ li {
 
 .author {
   display: inline-block;
+  vertical-align: bottom;
+  margin-top: 4px;
+  margin-right: 4px;
 }

--- a/public/src/app/issue-list/issue-list.component.html
+++ b/public/src/app/issue-list/issue-list.component.html
@@ -3,8 +3,8 @@
     <li *ngFor="let issue of issues">
       <span class="label">
         <a class="author" title="{{issue.author.login}}" target="_blank" href="{issue.author.url}}"><img class="avatar-22" src="{{issue.author.avatarUrl}}&size=22"></a>
-        <a class="issue" title="{{issue.title}}" target="_blank" href="{{issue.url}}">{{issue.number}}: {{issue.title}}</a>
-        <span *ngFor="let label of issue.labels.nodes"><span class="issue-label" [style]="issueColor(label)">{{labelName(label.name)}}</span><wbr /></span>
+        <a class="issue" title="{{issue.title}}" target="_blank" href="{{issue.url}}"><b>{{issue.number}}</b> {{issue.title}}</a>
+        <span *ngFor="let label of issue.labels?.nodes"><span class="issue-label" [style]="issueColor(label)">{{labelName(label.name)}}</span><wbr /></span>
       </span>
     </li>
   </ul>

--- a/public/src/app/pull-request/pull-request.component.css
+++ b/public/src/app/pull-request/pull-request.component.css
@@ -102,3 +102,51 @@
 .cherry-pick {
   color: rgba(0,0,0,0.5);
 }
+
+.pull-request {
+  position: relative;
+}
+
+.pull-request-detail {
+  display: none;
+  position: absolute;
+  right: 4px;
+  top: 30px;
+  text-align: left;
+  z-index: 10;
+  background: #fcfffc;
+  border: solid 1px #4c4c30;
+  border-radius: 0 0 4px 4px;
+  box-shadow: 2px 2px 4px rgba(0,0,0,0.5);
+  padding: 3px;
+  width: max-content;
+  max-width: 720px;
+  font-size: 10pt;
+}
+
+.pull-request:hover > .pull-request-detail {
+  display: block;
+}
+
+.branches {
+  display: block;
+}
+
+.branch {
+  color: #0366d6;
+  background: #eff7ff;
+  font-family: SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace;
+  border-radius: 6px;
+  padding: 0 5px;
+  display: inline-block;
+  margin: 0 2px;
+ }
+
+ .title {
+   display: block;
+   font-weight: bold;
+ }
+
+ .status {
+   display: block;
+ }

--- a/public/src/app/pull-request/pull-request.component.html
+++ b/public/src/app/pull-request/pull-request.component.html
@@ -1,6 +1,13 @@
+<span class="pull-request">
 <span class="label {{class || pullClass()}} {{pullStatus()}}">
   <a class="author" title="{{pull.pull.node.author.login}}" target="_blank" href="{{pull.pull.node.author.url}}"><img class="avatar-32" src="{{pull.pull.node.author.avatarUrl}}&size=32"></a>
-  <a class="pull" title="{{pull.pull.node.title}}{{pull.state ? ': '+pull.state.description : ''}}" target="_blank" href="{{pull.pull.node.url}}">
+  <a class="pull" target="_blank" href="{{pull.pull.node.url}}">
     <span *ngIf='pullIsCherryPick()' class='cherry-pick'>🍒 </span>{{pull.pull.node.number}}
   </a>
+</span>
+<div class="pull-request-detail">
+  <span class="branches"><span class="branch">{{pull.pull.node.baseRefName}}</span> &larr; <span class="branch">{{pull.pull.node.headRefName}}</span></span>
+  <span class="title">{{pull.pull.node.title}}</span>
+  <span class="status">{{pull.state?.description}}</span>
+</div>
 </span>

--- a/public/src/main.ts
+++ b/public/src/main.ts
@@ -10,3 +10,4 @@ if (environment.production) {
 
 platformBrowserDynamic().bootstrapModule(AppModule)
   .catch(err => console.error(err));
+


### PR DESCRIPTION
Hovering over a milestone will show the list of issues for that milestone (except for `Future` milestone):
![image](https://user-images.githubusercontent.com/4498365/89242250-6f33b000-d644-11ea-86c5-940d9c270db9.png)

Hovering over a pull request will show details of the PR:
![image](https://user-images.githubusercontent.com/4498365/89242298-8ecad880-d644-11ea-857c-d61cfce4411c.png)

Query cost for GitHub remains 60 (if I add labels to the list of issues, then it goes up to 100+...)