### PR TITLE
feat: read issue details as separate list

### DIFF
--- a/github-issues.js
+++ b/github-issues.js
@@ -1,0 +1,47 @@
+exports.queryString = function(after) {
+  after = JSON.stringify(after);
+  return `
+  {
+    search(first: 100, after:${after} type: ISSUE, query:"org:keymanapp is:open is:issue") {
+      issueCount
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      nodes {
+        ... on Issue {
+          repository {
+            name
+          }
+
+          author {
+            login
+            avatarUrl
+            url
+          }
+
+          title
+          number
+          url
+
+          labels(first:20) {
+            nodes {
+              color
+              name
+            }
+          }
+
+          milestone {
+            title
+          }
+
+        }
+      }
+    }
+
+    rateLimit {
+      cost
+    }
+  }
+  `
+};

--- a/github-status.js
+++ b/github-status.js
@@ -80,21 +80,6 @@ exports.queryString = function(sprint) {
           name
           openIssues: issues(first: 100, filterBy: {states: [OPEN]}) {
             totalCount
-            nodes {
-
-              author {
-                login
-                avatarUrl
-                url
-              }
-              title
-              number
-              url
-
-              milestone {
-                title
-              }
-            }
           }
         }
       }
@@ -179,23 +164,6 @@ exports.queryString = function(sprint) {
     repositories(first: 30) {
       nodes {
         name
-        issuesByMilestone: issues(first: 100, filterBy: {states: [OPEN]}) {
-          totalCount
-          nodes {
-            author {
-              login
-              avatarUrl
-              url
-            }
-            title
-            number
-            url
-
-            milestone {
-              title
-            }
-          }
-        }
         pullRequests(last: 50, states: OPEN) {
           edges {
             node {

--- a/public/src/app/app.component.html
+++ b/public/src/app/app.component.html
@@ -149,9 +149,7 @@
         </td>
 
         <td class="issues">
-          <a class="issue-count" target="_blank" href="https://github.com/keymanapp/keyman/issues?q=is%3Aopen+is%3Aissue+label%3A{{platform.value.id}}/">{{platform.value.totalIssueCount}}
-            <span *ngIf="platform.value.totalIssueCount > 100" title="Too many issues — values shown are incomplete">⚠</span>
-          </a>
+          <a class="issue-count" target="_blank" href="https://github.com/keymanapp/keyman/issues?q=is%3Aopen+is%3Aissue+label%3A{{platform.value.id}}/">{{platform.value.totalIssueCount}}</a>
 
           <ng-container *ngFor="let milestone of platform.value.milestones">
             <span class="issue-box">

--- a/public/src/app/app.component.ts
+++ b/public/src/app/app.component.ts
@@ -263,7 +263,9 @@ export class AppComponent {
         { id: 'waiting', title: "Waiting-external", count: 0, nodes: [] },
         { id: 'other', title: "Other", count: 0, nodes: [] }
       ];
-      label.node.openIssues.nodes.forEach(issue => {
+      this.status.issues
+        .filter(issue => issue.repository.name === 'keyman' && issue.labels.nodes.some(l=>l.name === label.node.name))
+        .forEach(issue => {
         let m = null;
         if(!issue.milestone) m = platform.milestones[3];
         else switch(issue.milestone.title) {
@@ -297,7 +299,9 @@ export class AppComponent {
         { id: 'waiting', title: "Waiting-external", count: 0, nodes: [] },
         { id: 'other', title: "Other", count: 0, nodes: [] }
       ];
-      repo.issuesByMilestone.nodes.forEach(issue => {
+      this.status.issues
+        .filter(issue => issue.repository.name === repo.name)
+        .forEach(issue => {
         let m = null;
         if(!issue.milestone) m = site.milestones[3];
         else switch(issue.milestone.title) {

--- a/public/src/app/issue-list/issue-list.component.css
+++ b/public/src/app/issue-list/issue-list.component.css
@@ -5,7 +5,6 @@
   box-shadow: 2px 2px 4px rgba(0,0,0,0.5);
   padding: 0 3px 3px 3px;
   width: max-content;
-  max-width: 720px;
 }
 
 ul {
@@ -44,8 +43,9 @@ li {
 
 .issue-label {
   margin-left: 3px;
-  border-radius: 2px;
-  padding: 2px;
+  border-radius: 10px;
+  padding: 2px 6px;
+  font-weight: 500;
   word-wrap: break-word;
   word-break: normal;
   white-space: normal;


### PR DESCRIPTION
For performance and complexity reasons, it turns out to be
a lot easier to just read the list of issues from GitHub as
a separate chain of queries. This has an additional cost of
5 points but we will still be well under our threshold (we
may be able to simplify a few other places as well later).

(Not unified yet: unlabeled issues)