### PR TITLE
fix: download filenames and feat: clipboard support

### DIFF
--- a/code.js
+++ b/code.js
@@ -300,13 +300,14 @@ function transformKeymanResponse(data) {
     Object.keys(data[platform]).forEach(tier => {
       const version = data[platform][tier].version;
       const prefix = `https://downloads.keyman.com/${platform}/${tier}/${version}`;
+      const winapp = parseInt(version,10) >= 14 ? 'keyman' : 'keymandesktop';
       switch(platform) {
         case 'android':   data[platform][tier].downloadUrl = `${prefix}/keyman-${version}.apk`; break;
         case 'ios':       data[platform][tier].downloadUrl = `${prefix}/keyman-ios-${version}.ipa`; break;
         case 'linux':     data[platform][tier].downloadUrl = `${prefix}/`; break;
         case 'mac':       data[platform][tier].downloadUrl = `${prefix}/keyman-${version}.dmg`; break;
         case 'web':       data[platform][tier].downloadUrl = `https://keymanweb.com?version=${version}`; break;
-        case 'windows':   data[platform][tier].downloadUrl = `${prefix}/keymandesktop-${version}.exe`; break;
+        case 'windows':   data[platform][tier].downloadUrl = `${prefix}/${winapp}-${version}.exe`; break;
         case 'developer': data[platform][tier].downloadUrl = `${prefix}/keymandeveloper-${version}.exe`; break;
       }
     });

--- a/public/src/app/app.component.css
+++ b/public/src/app/app.component.css
@@ -301,7 +301,7 @@ app-issue-list {
 }
 
 .tr-site .issue-box app-issue-list {
-  bottom: 22px;
+  bottom: 21px;
   left: 2px;
 }
 

--- a/public/src/app/app.component.html
+++ b/public/src/app/app.component.html
@@ -37,7 +37,10 @@
                     </thead>
                     <tbody>
                       <tr>
-                        <th>Issues</th>
+                        <th>
+                          Issues
+                          <app-clipboard [text]="getContributionIssueText(user)" title="Copy HTML formatted list of issues to clipboard"></app-clipboard>
+                        </th>
                         <td  *ngFor="let day of sprintDays">
                           <span *ngFor="let issue of user.contributions.issues.nodes | filterObjectByDate: day.date">
                             <a class='contribution-issue' href='{{issue.issue.url}}' target='_blank' title='{{issue.issue.title}}'>{{issue.issue.number}}</a>
@@ -45,7 +48,10 @@
                         </td>
                       </tr>
                       <tr>
-                        <th>PRs</th>
+                        <th>
+                          PRs
+                          <app-clipboard [text]="getContributionPRText(user)" title="Copy HTML formatted list of pull requests to clipboard"></app-clipboard>
+                        </th>
                         <td *ngFor="let day of sprintDays">
                           <span *ngFor="let pr of user.contributions.pullRequests.nodes | filterObjectByDate: day.date">
                             <a class='contribution-issue' href='{{pr.pullRequest.url}}' target='_blank' title='{{pr.pullRequest.title}}'>{{pr.pullRequest.number}}</a>
@@ -53,7 +59,10 @@
                         </td>
                       </tr>
                       <tr>
-                        <th>Reviews</th>
+                        <th>
+                          Reviews
+                          <app-clipboard [text]="getContributionReviewText(user)" title="Copy HTML formatted list of reviews to clipboard"></app-clipboard>
+                        </th>
                         <td *ngFor="let day of sprintDays">
                           <span *ngFor="let review of user.contributions.reviews.nodes | filterObjectByDate: day.date">
                             <a class='contribution-issue' href='{{review.pullRequest.url}}' target='_blank' title='{{review.pullRequest.title}}'>{{review.pullRequest.number}}</a>

--- a/public/src/app/app.component.ts
+++ b/public/src/app/app.component.ts
@@ -384,4 +384,49 @@ export class AppComponent {
     const build = this.tierTestRunningAndLatestBuild(platformId,tier);
     return build ? `https://build.palaso.org/viewLog.html?buildId=${build.id}` : null;
   }
+
+  escapeHtml(unsafe) {
+    return unsafe
+         .replace(/&/g, "&amp;")
+         .replace(/</g, "&lt;")
+         .replace(/>/g, "&gt;")
+         .replace(/"/g, "&quot;")
+         .replace(/'/g, "&#039;");
+  }  
+
+  repoShortName(url) {
+    const matches = url.match(/\/github.com\/keymanapp\/([^\/]+)\//);
+    if(!matches) return '';
+    switch(matches[1]) {
+      case 'keyman': return '';
+      case 'keyman.com': return 'keyman.com';
+    }
+
+    const submatches = matches[1].match(/^([^.]+)\.keyman\.com/);
+    return submatches ? submatches[1] : matches[1];
+  }
+
+  getContributionText(nodes, type) {
+    const text = 
+      '<ul>' + 
+      nodes.reduce(
+        (text, node) => {
+          const repo = this.repoShortName(node[type].url);
+          return text + `<li>${this.escapeHtml(node[type].title)} (<a href='${node[type].url}'>${repo}#${node[type].number}</a>)</li>\n`
+        }, '') +
+      '</ul>';
+    return { content: text, type: 'text/html' };
+  }
+
+  getContributionPRText(user) { 
+    return this.getContributionText(user.contributions.pullRequests.nodes, 'pullRequest');
+  }
+
+  getContributionIssueText(user) {
+    return this.getContributionText(user.contributions.issues.nodes, 'issue');
+  }
+
+  getContributionReviewText(user) {
+    return this.getContributionText(user.contributions.reviews.nodes, 'pullRequest');
+  }
 }

--- a/public/src/app/app.component.ts
+++ b/public/src/app/app.component.ts
@@ -3,6 +3,8 @@ import { ActivatedRoute } from '@angular/router';
 import { StatusService } from './status/status.service';
 import { platforms, PlatformSpec } from './platforms';
 import { sites } from './sites';
+import { repoShortNameFromGithubUrl } from './utility/repoShortNameFromGithubUrl';
+import { escapeHtml } from './utility/escapeHtml';
 
 @Component({
   selector: 'app-root',
@@ -385,34 +387,13 @@ export class AppComponent {
     return build ? `https://build.palaso.org/viewLog.html?buildId=${build.id}` : null;
   }
 
-  escapeHtml(unsafe) {
-    return unsafe
-         .replace(/&/g, "&amp;")
-         .replace(/</g, "&lt;")
-         .replace(/>/g, "&gt;")
-         .replace(/"/g, "&quot;")
-         .replace(/'/g, "&#039;");
-  }  
-
-  repoShortName(url) {
-    const matches = url.match(/\/github.com\/keymanapp\/([^\/]+)\//);
-    if(!matches) return '';
-    switch(matches[1]) {
-      case 'keyman': return '';
-      case 'keyman.com': return 'keyman.com';
-    }
-
-    const submatches = matches[1].match(/^([^.]+)\.keyman\.com/);
-    return submatches ? submatches[1] : matches[1];
-  }
-
   getContributionText(nodes, type) {
     const text = 
       '<ul>' + 
       nodes.reduce(
         (text, node) => {
-          const repo = this.repoShortName(node[type].url);
-          return text + `<li>${this.escapeHtml(node[type].title)} (<a href='${node[type].url}'>${repo}#${node[type].number}</a>)</li>\n`
+          const repo = repoShortNameFromGithubUrl(node[type].url);
+          return text + `<li>${escapeHtml(node[type].title)} (<a href='${node[type].url}'>${repo}#${node[type].number}</a>)</li>\n`
         }, '') +
       '</ul>';
     return { content: text, type: 'text/html' };

--- a/public/src/app/app.module.ts
+++ b/public/src/app/app.module.ts
@@ -9,10 +9,12 @@ import { FilterObjectByDatePipe } from './pipes/filter-object-by-date.pipe';
 import { CountBoxComponent } from './count-box/count-box.component';
 import { SentryComponent } from './sentry/sentry.component';
 import { IssueListComponent } from './issue-list/issue-list.component';
+import { ClipboardComponent } from './clipboard/clipboard.component';
 
 @NgModule({
   declarations: [
     AppComponent,
+    ClipboardComponent,
     PullRequestComponent,
     CountBoxComponent,
     FilterObjectByDatePipe,

--- a/public/src/app/clipboard/clipboard.component.css
+++ b/public/src/app/clipboard/clipboard.component.css
@@ -1,0 +1,1 @@
+span { cursor: pointer; }

--- a/public/src/app/clipboard/clipboard.component.html
+++ b/public/src/app/clipboard/clipboard.component.html
@@ -1,0 +1,1 @@
+<span (click)="copyToClipboard()" title="{{title}}">📋</span>

--- a/public/src/app/clipboard/clipboard.component.spec.ts
+++ b/public/src/app/clipboard/clipboard.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ClipboardComponent } from './clipboard.component';
+
+describe('ClipboardComponent', () => {
+  let component: ClipboardComponent;
+  let fixture: ComponentFixture<ClipboardComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ClipboardComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ClipboardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/public/src/app/clipboard/clipboard.component.ts
+++ b/public/src/app/clipboard/clipboard.component.ts
@@ -1,0 +1,36 @@
+import { Component, OnInit, Input } from '@angular/core';
+
+// ClipboardItem and Clipboard.write are not yet in current types.d.ts
+declare class ClipboardItem {
+  constructor(data: { [mimeType: string]: Blob });
+}
+
+declare class Clipboard extends globalThis.Clipboard {
+  write(items: [ClipboardItem]);
+}
+
+@Component({
+  selector: 'app-clipboard',
+  templateUrl: './clipboard.component.html',
+  styleUrls: ['./clipboard.component.css']
+})
+export class ClipboardComponent implements OnInit {
+  @Input() text: any;
+  @Input() title: any;
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+  copyToClipboard() {
+    // async but we don't need to wait around for the answer
+    const clipText = 
+      typeof this.text == 'function' ? this.text() : this.text;
+    if(typeof clipText == 'object') {
+      (navigator.clipboard as Clipboard).write([new ClipboardItem({[clipText.type]: new Blob([clipText.content], {type: clipText.type}) })]);
+    } else {
+      navigator.clipboard.writeText(clipText);
+    }
+  }
+}

--- a/public/src/app/issue-list/issue-list.component.html
+++ b/public/src/app/issue-list/issue-list.component.html
@@ -8,4 +8,5 @@
       </span>
     </li>
   </ul>
+  <app-clipboard [text]="getIssueListText()" title="Copy list of issues to clipboard"></app-clipboard>
 </div>

--- a/public/src/app/issue-list/issue-list.component.ts
+++ b/public/src/app/issue-list/issue-list.component.ts
@@ -1,5 +1,7 @@
 import { Component, OnInit, Input } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
+import { repoShortNameFromGithubUrl } from '../utility/repoShortNameFromGithubUrl';
+import { escapeHtml } from '../utility/escapeHtml';
 
 @Component({
   selector: 'app-issue-list',
@@ -55,5 +57,19 @@ export class IssueListComponent implements OnInit {
     }
 
     return this.rgbToYIQ(rgb) >= threshold ? '#000' : '#fff';
+  }
+
+  getIssueListText() {
+    if(!this.issues) return null;
+    
+    const text = 
+      '<ul>' + 
+      this.issues.reduce(
+        (text, node) => {
+          const repo = repoShortNameFromGithubUrl(node.url);
+          return text + `<li>${escapeHtml(node.title)} (<a href='${node.url}'>${repo}#${node.number}</a>)</li>\n`
+        }, '') +
+      '</ul>';
+    return { content: text, type: 'text/html' };
   }
 }

--- a/public/src/app/pull-request/pull-request.component.css
+++ b/public/src/app/pull-request/pull-request.component.css
@@ -111,7 +111,7 @@
   display: none;
   position: absolute;
   right: 4px;
-  top: 30px;
+  top: 29px;
   text-align: left;
   z-index: 10;
   background: #fcfffc;

--- a/public/src/app/pull-request/pull-request.component.html
+++ b/public/src/app/pull-request/pull-request.component.html
@@ -6,7 +6,11 @@
   </a>
 </span>
 <div class="pull-request-detail">
-  <span class="branches"><span class="branch">{{pull.pull.node.baseRefName}}</span> &larr; <span class="branch">{{pull.pull.node.headRefName}}</span></span>
+  <span class="branches">
+    <span class="branch">{{pull.pull.node.baseRefName}}</span> &larr; <span class="branch">{{pull.pull.node.headRefName}}</span> 
+    <app-clipboard [text]="pull.pull.node.headRefName" title="Copy head branch name to clipboard"></app-clipboard>
+  </span>
+  
   <span class="title">{{pull.pull.node.title}}</span>
   <span class="status">{{pull.state?.description}}</span>
 </div>

--- a/public/src/app/utility/escapeHtml.ts
+++ b/public/src/app/utility/escapeHtml.ts
@@ -1,0 +1,12 @@
+/**
+ * Escapes 5 entities found in string for HTML: &, <, >, " and '
+ * @param unsafe string of text to escape
+ */
+export function escapeHtml(unsafe: string): string {
+    return unsafe
+         .replace(/&/g, "&amp;")
+         .replace(/</g, "&lt;")
+         .replace(/>/g, "&gt;")
+         .replace(/"/g, "&quot;")
+         .replace(/'/g, "&#039;");
+  }  

--- a/public/src/app/utility/repoShortNameFromGithubUrl.ts
+++ b/public/src/app/utility/repoShortNameFromGithubUrl.ts
@@ -1,0 +1,16 @@
+/**
+ * Extracts the repo short name from a GitHub URL, for use with issue 
+ * and pull request references, returning #1234, api#77, etc.
+ * @param url A GitHub url, e.g. https://github.com/keymanapp/keyman/...
+ */
+export function repoShortNameFromGithubUrl(url: string): string {
+    const matches = url.match(/\/github.com\/keymanapp\/([^\/]+)\//);
+    if(!matches) return '';
+    switch(matches[1]) {
+      case 'keyman': return '';
+      case 'keyman.com': return 'keyman.com';
+    }
+
+    const submatches = matches[1].match(/^([^.]+)\.keyman\.com/);
+    return submatches ? submatches[1] : matches[1];
+  }


### PR DESCRIPTION
1. fix: use new keyman-version.exe filenames
* When referencing Keyman for Windows 14.0 or later, use new filename format keyman-x.x.x.exe.

2. fix: tweak placement of popups
* Moving cursor onto popups could cause the popups to hide themselves due to a 1px misalignment.

3. feat: add clipboard shortcuts
* Adds clipboard shortcuts for branch names, contribution reports, and issue lists.

![image](https://user-images.githubusercontent.com/4498365/96377699-fff54300-11d2-11eb-842b-859479e3e22b.png)

![image](https://user-images.githubusercontent.com/4498365/96377706-0c799b80-11d3-11eb-90d1-07da5a5d1370.png)

![image](https://user-images.githubusercontent.com/4498365/96388937-1c57a680-11f8-11eb-8334-b33fb7b905bc.png)

Note that the contribution reports and issue lists are currently copied *only* as HTML, which means you can only paste them into places that accept HTML (e.g. Google Docs, Word, but not textarea).