### PR TITLE
fix: Improve Pull Request status reporting

### DIFF
--- a/github-status.js
+++ b/github-status.js
@@ -184,8 +184,9 @@ exports.queryString = function(sprint) {
               commits(last: 1) {
                 nodes {
                   commit {
-                    checkSuites(last:1) {
+                    checkSuites(last: 10) {
                       nodes {
+                        app { name }
                         conclusion
                         status
                       }

--- a/public/src/app/app.component.ts
+++ b/public/src/app/app.component.ts
@@ -145,24 +145,20 @@ export class AppComponent {
   transformPlatformStatusData() {
     this.labeledPulls = [];
 
-    for(let p in this.platforms) {
-      let platform = this.platforms[p];
+    for(let platform of this.platforms) {
       platform.pulls = [];
       //console.log(this.status.github.data.repository.pullRequests.edges);
-      for(let q in this.status.github.data.repository.pullRequests.edges) {
-        let pull=this.status.github.data.repository.pullRequests.edges[q];
+      for(let pull of this.status.github.data.repository.pullRequests.edges) {
         //console.log(pull);
         let labels = pull.node.labels.edges;
         let status = pull.node.commits.edges[0].node.commit.status;
         let contexts = status ? status.contexts : null;
-        for(let l in labels) {
-          let label = labels[l].node;
-          if(label.name == platform.id+'/') {
+        for(let label of labels) {
+          if(label.node.name == platform.id+'/') {
             let foundContext = null;
-            for(let r in contexts) {
-              let context=contexts[r];
+            for(let context of contexts) {
               //
-              if(context.context == platform.context) {
+              if(context.context.includes(platform.context)) {
                 foundContext = context;
                 break;
               }

--- a/public/src/app/app.component.ts
+++ b/public/src/app/app.component.ts
@@ -157,12 +157,15 @@ export class AppComponent {
           if(label.node.name == platform.id+'/') {
             let foundContext = null;
             for(let context of contexts) {
-              //
-              if(context.context.includes(platform.context)) {
+              if(context.state != 'SUCCESS') {
                 foundContext = context;
                 break;
               }
+              if(context.context.match(new RegExp('Test-\\d\\d\\.\\d \\('+platform.context+'\\)'))) {
+                foundContext = context;
+              }
             }
+            if(contexts.length && !foundContext) foundContext = contexts[0];
             platform.pulls.push({pull: pull, state: foundContext});
             this.labeledPulls.push(pull);
           }

--- a/public/src/app/platforms.ts
+++ b/public/src/app/platforms.ts
@@ -13,48 +13,48 @@ export const platforms: PlatformSpec[] = [
     id:'android',
     name:'Android',
     configs:{"alpha": "KeymanAndroid_Build", "beta": "KeymanAndroid_Beta", "stable": "KeymanAndroid_Stable", test: "KeymanAndroid_TestPullRequests"},
-    context: "Test (Keyman - Android)"
+    context: "(Keyman - Android)"
   },
   {
     id:'ios',
     name:'iOS',
     configs:{"alpha": "Keyman_iOS_Master", "beta": "Keyman_iOS_Beta", "stable": "Keyman_iOS_Stable", test: "Keyman_iOS_TestPullRequests"},
-    context: "Test (Keyman - iOS)"
+    context: "(Keyman - iOS)"
   },
   {
     id:'linux',
     name:'Linux',
     configs:{"alpha": "KeymanLinux_Master", "beta": "KeymanLinux_Beta", "stable": "KeymanLinux_Stable", test: "KeymanLinux_TestPullRequests"},
-    context: "Test (Keyman - Linux)"
+    context: "(Keyman - Linux)"
   },
   {
     id:'mac',
     name:'macOS',
     configs:{"alpha": "KeymanMac_Master", "beta": "KeymanMac_Beta", "stable": "KeymanMac_Stable", test: "Keyman_KeymanMac_PullRequests"},
-    context: "Test (Keyman - macOS)"
+    context: "(Keyman - macOS)"
   },
   {
     id:'web',
     name:'KeymanWeb',
     configs:{"alpha": "Keymanweb_Build", "beta": "Keymanweb_Beta", "stable": "Keymanweb_Stable", test: "Keymanweb_TestPullRequests"},
-    context: "Test (Keyman - Web)"
+    context: "(Keyman - Web)"
   },
   {
     id:'windows',
     name:'Windows',
     configs:{"alpha": "Keyman_Build", "beta": "KeymanDesktop_Beta", "stable": "KeymanDesktop_Stable", test: "KeymanDesktop_TestPullRequests"},
-    context: "Test (Keyman - Windows (Desktop/Developer))"
+    context: "(Keyman - Windows (Desktop/Developer))"
   },
   {
     id:'developer',
     name:'Developer',
     configs:{"alpha": "Keyman_Build", "beta": "KeymanDesktop_Beta", "stable": "KeymanDesktop_Stable", test: "KeymanDesktop_TestPullRequests"},
-    context: "Test (Keyman - Windows (Desktop/Developer))"
+    context: "(Keyman - Windows (Desktop/Developer))"
   },
   {
     id:'common',
     name:'Common',
     configs: null,
-    context: "Test: Keyman Core - Linux (Common)"
+    context: "(Common)"
   },
 ];

--- a/public/src/app/platforms.ts
+++ b/public/src/app/platforms.ts
@@ -13,48 +13,48 @@ export const platforms: PlatformSpec[] = [
     id:'android',
     name:'Android',
     configs:{"alpha": "KeymanAndroid_Build", "beta": "KeymanAndroid_Beta", "stable": "KeymanAndroid_Stable", test: "KeymanAndroid_TestPullRequests"},
-    context: "(Keyman - Android)"
+    context: "Keyman - Android"
   },
   {
     id:'ios',
     name:'iOS',
     configs:{"alpha": "Keyman_iOS_Master", "beta": "Keyman_iOS_Beta", "stable": "Keyman_iOS_Stable", test: "Keyman_iOS_TestPullRequests"},
-    context: "(Keyman - iOS)"
+    context: "Keyman - iOS"
   },
   {
     id:'linux',
     name:'Linux',
     configs:{"alpha": "KeymanLinux_Master", "beta": "KeymanLinux_Beta", "stable": "KeymanLinux_Stable", test: "KeymanLinux_TestPullRequests"},
-    context: "(Keyman - Linux)"
+    context: "Keyman - Linux"
   },
   {
     id:'mac',
     name:'macOS',
     configs:{"alpha": "KeymanMac_Master", "beta": "KeymanMac_Beta", "stable": "KeymanMac_Stable", test: "Keyman_KeymanMac_PullRequests"},
-    context: "(Keyman - macOS)"
+    context: "Keyman - macOS"
   },
   {
     id:'web',
     name:'KeymanWeb',
     configs:{"alpha": "Keymanweb_Build", "beta": "Keymanweb_Beta", "stable": "Keymanweb_Stable", test: "Keymanweb_TestPullRequests"},
-    context: "(Keyman - Web)"
+    context: "Keyman - Web"
   },
   {
     id:'windows',
     name:'Windows',
     configs:{"alpha": "Keyman_Build", "beta": "KeymanDesktop_Beta", "stable": "KeymanDesktop_Stable", test: "KeymanDesktop_TestPullRequests"},
-    context: "(Keyman - Windows (Desktop/Developer))"
+    context: "Keyman - Windows \\(Desktop\\/Developer\\)"
   },
   {
     id:'developer',
     name:'Developer',
     configs:{"alpha": "Keyman_Build", "beta": "KeymanDesktop_Beta", "stable": "KeymanDesktop_Stable", test: "KeymanDesktop_TestPullRequests"},
-    context: "(Keyman - Windows (Desktop/Developer))"
+    context: "Keyman - Windows \\(Desktop\\/Developer\\)"
   },
   {
     id:'common',
     name:'Common',
     configs: null,
-    context: "(Common)"
+    context: "Common"
   },
 ];

--- a/public/src/app/pull-request/pull-request.component.html
+++ b/public/src/app/pull-request/pull-request.component.html
@@ -12,6 +12,6 @@
   </span>
   
   <span class="title">{{pull.pull.node.title}}</span>
-  <span class="status">{{pull.state?.description}}</span>
+  <span class="status">{{pull.state ? pull.state.context + ': ' + pull.state.description : ''}}</span>
 </div>
 </span>


### PR DESCRIPTION
Pull Requests don't always show status correctly, for two reasons:

1. GitHub sometimes returns a null status check with a QUEUED state, which the app then saw instead of the correct status check. We see this for the website status checks.

2. We renamed the TC configurations and added versioning into them, which means we need to test only on the parent project name rather than the full status check. This should work into the future as well, when we have new status checks that have the same name pattern.

Also, if any build check fails, this will now be highlighted. The algorithm attempts to find the best corresponding build check for all platforms otherwise, and defaults to the first if no perfect match is found ( which may happen on Common at least).

We still only show one of the status checks in this view but at least we get better reporting of when one fails.