### PR TITLE
fix: correct milestone sorting

### DIFF
--- a/public/src/app/app.component.ts
+++ b/public/src/app/app.component.ts
@@ -269,7 +269,7 @@ export class AppComponent {
     };
 
     let sortMilestones = (a,b) => {
-      const sprintMilestone = /^P(\d+)S(\d+)$/;
+      const sprintMilestone = /^[A-Z](\d+)S(\d+)$/;
       let a0 = sprintMilestone.exec(a.title), b0 = sprintMilestone.exec(b.title);
       if(a0 !== null && b0 === null) return -1;
       if(a0 === null && b0 !== null) return 1;


### PR DESCRIPTION
We changed the naming for our milestones from `PddSdd` to `AddSdd` or `BddSdd`. This wasn't accounted for in the milestone sorting, causing `A15S01` to be sorted before `A14S08`. 

This change restores the chronological sorting based on milestone and sprint numbers.