### PR TITLE
feat: Add Linux deployment status for beta and alpha versions

### DIFF
--- a/public/src/app/app.component.ts
+++ b/public/src/app/app.component.ts
@@ -141,6 +141,9 @@ export class AppComponent {
             case StatusSource.SKeymanCom:
             case StatusSource.LaunchPad:
             case StatusSource.PackagesSilOrg:
+            case StatusSource.LinuxLsdevSilOrgAlpha:
+            case StatusSource.LinuxLsdevSilOrgBeta:
+            case StatusSource.LinuxLsdevSilOrgStable:
             case StatusSource.NpmLexicalModelCompiler:
             case StatusSource.NpmModelsTypes:
               this.status.deployment[source] = data.data;

--- a/public/src/app/deploy-box/deploy-box.component.ts
+++ b/public/src/app/deploy-box/deploy-box.component.ts
@@ -70,17 +70,33 @@ export class DeployBoxComponent implements OnInit, OnChanges {
           });
         break;
       case 'linux':
-        if(this.tier == 'stable')
+        if (this.tier == 'stable') {
           this.targets.push({
             name: 'Launchpad',
             url: 'https://launchpad.net/~keymanapp/+archive/ubuntu/keyman',
             version: this.status?.deployment?.['launch-pad']?.version,
-            date:this.status?.deployment?.['launch-pad']?.date_published.substr(0,10)
+            date: this.status?.deployment?.['launch-pad']?.date_published.substr(0, 10)
           }, {
             name: 'packages.sil.org',
             url: 'https://packages.sil.org/ubuntu/?prefix=ubuntu/pool/main/k/keyman-config/',
             version: this.status?.deployment?.['packages-sil-org']?.version
+          }, {
+            name: 'linux.lsdev.sil.org',
+            url: 'http://linux.lsdev.sil.org/ubuntu/pool/main/k/keyman-config/',
+            version: this.status?.deployment?.['linux-lsdev-sil-org-stable']?.version
           });
+        } else if (this.tier == 'beta' || this.tier == 'alpha') {
+          this.targets.push({
+            name: 'Launchpad',
+            url: `https://launchpad.net/~keymanapp/+archive/ubuntu-${this.tier}/keyman`,
+            version: this.status?.deployment?.['launch-pad']?.version,
+            date: this.status?.deployment?.['launch-pad']?.date_published.substr(0, 10)
+          }, {
+            name: 'linux.lsdev.sil.org',
+            url: 'http://linux.lsdev.sil.org/ubuntu/pool/main/k/keyman-config/',
+            version: this.status?.deployment?.[`linux-lsdev-sil-org-${this.tier}`]?.version
+          });
+        }
         break;
       case 'web':
         this.targets.push({

--- a/server/code.ts
+++ b/server/code.ts
@@ -45,7 +45,10 @@ const STATUS_SOURCES: StatusSource[] = [
   StatusSource.NpmLexicalModelCompiler,
   StatusSource.NpmModelsTypes,
   StatusSource.SKeymanCom,
-  StatusSource.PackagesSilOrg
+  StatusSource.PackagesSilOrg,
+  StatusSource.LinuxLsdevSilOrgAlpha,
+  StatusSource.LinuxLsdevSilOrgBeta,
+  StatusSource.LinuxLsdevSilOrgStable
 ];
 
 initialLoad();

--- a/server/data/status-data.ts
+++ b/server/data/status-data.ts
@@ -12,6 +12,9 @@ import playStoreService from "../services/deployment/play-store";
 import sKeymanComService from "../services/deployment/s-keyman-com";
 import launchPadService from "../services/deployment/launch-pad";
 import packagesSilOrgService from "../services/deployment/packages-sil-org";
+import linuxLsdevSilOrgAlphaService from "../services/deployment/linux-lsdev-sil-org-alpha";
+import linuxLsdevSilOrgBetaService from "../services/deployment/linux-lsdev-sil-org-beta";
+import linuxLsdevSilOrgStableService from "../services/deployment/linux-lsdev-sil-org-stable";
 import { lmcService, mtService } from "../services/deployment/npmjs";
 import { StatusSource } from "../../shared/status-source";
 
@@ -21,6 +24,9 @@ services[StatusSource.PlayStore] = playStoreService;
 services[StatusSource.SKeymanCom] = sKeymanComService;
 services[StatusSource.LaunchPad] = launchPadService;
 services[StatusSource.PackagesSilOrg] = packagesSilOrgService;
+services[StatusSource.LinuxLsdevSilOrgAlpha] = linuxLsdevSilOrgAlphaService;
+services[StatusSource.LinuxLsdevSilOrgBeta] = linuxLsdevSilOrgBetaService;
+services[StatusSource.LinuxLsdevSilOrgStable] = linuxLsdevSilOrgStableService;
 services[StatusSource.NpmLexicalModelCompiler] = lmcService;
 services[StatusSource.NpmModelsTypes] = mtService;
 

--- a/server/services/deployment/linux-lsdev-sil-org-alpha.ts
+++ b/server/services/deployment/linux-lsdev-sil-org-alpha.ts
@@ -1,0 +1,35 @@
+/*
+ Service to collect version info from linux.lsdev.sil.org (LLSO)
+ for the current ALPHA version.
+ This endpoint returns text which we will skim for specific text:
+
+```
+Package: keyman
+Source: keyman-config (14.0.273-1)
+Version: 14.0.273-1+focal1
+```
+
+*/
+
+import httpget from "../../util/httpget";
+import DataService from "../data-service";
+
+// http://linux.lsdev.sil.org/ubuntu/dists/focal-experimental/main/binary-amd64/Packages
+const HOST ='linux.lsdev.sil.org';
+const PATH='/ubuntu/dists/focal-experimental/main/binary-amd64/Packages';
+
+const service: DataService = {
+   get: function() {
+    return httpget(HOST, PATH).then((data) => {
+      const results = data.data.match(/^Package: keyman\s*\nSource:\s*keyman-config \((\d+\.\d+\.\d+)-\d+\)/m);
+      if(results) {
+        return { version: results[1] };
+      }
+
+      return null;
+    });
+  }
+};
+
+export default service;
+

--- a/server/services/deployment/linux-lsdev-sil-org-beta.ts
+++ b/server/services/deployment/linux-lsdev-sil-org-beta.ts
@@ -1,0 +1,35 @@
+/*
+ Service to collect version info from linux.lsdev.sil.org (LLSO)
+ for the current BETA version.
+ This endpoint returns text which we will skim for specific text:
+
+```
+Package: keyman
+Source: keyman-config (14.0.273-1)
+Version: 14.0.273-1+focal1
+```
+
+*/
+
+import httpget from "../../util/httpget";
+import DataService from "../data-service";
+
+// http://linux.lsdev.sil.org/ubuntu/dists/focal-proposed/main/binary-amd64/Packages
+const HOST ='linux.lsdev.sil.org';
+const PATH='/ubuntu/dists/focal-proposed/main/binary-amd64/Packages';
+
+const service: DataService = {
+   get: function() {
+    return httpget(HOST, PATH).then((data) => {
+      const results = data.data.match(/^Package: keyman\s*\nSource:\s*keyman-config \((\d+\.\d+\.\d+)-\d+\)/m);
+      if(results) {
+        return { version: results[1] };
+      }
+
+      return null;
+    });
+  }
+};
+
+export default service;
+

--- a/server/services/deployment/linux-lsdev-sil-org-stable.ts
+++ b/server/services/deployment/linux-lsdev-sil-org-stable.ts
@@ -1,0 +1,35 @@
+/*
+ Service to collect version info from linux.lsdev.sil.org (LLSO)
+ for the current STABLE version.
+ This endpoint returns text which we will skim for specific text:
+
+```
+Package: keyman
+Source: keyman-config (14.0.273-1)
+Version: 14.0.273-1+focal1
+```
+
+*/
+
+import httpget from "../../util/httpget";
+import DataService from "../data-service";
+
+// http://linux.lsdev.sil.org/ubuntu/dists/focal/main/binary-amd64/Packages
+const HOST ='linux.lsdev.sil.org';
+const PATH='/ubuntu/dists/focal/main/binary-amd64/Packages';
+
+const service: DataService = {
+   get: function() {
+    return httpget(HOST, PATH).then((data) => {
+      const results = data.data.match(/^Package: keyman\s*\nSource:\s*keyman-config \((\d+\.\d+\.\d+)-\d+\)/m);
+      if(results) {
+        return { version: results[1] };
+      }
+
+      return null;
+    });
+  }
+};
+
+export default service;
+

--- a/shared/status-source.ts
+++ b/shared/status-source.ts
@@ -12,6 +12,9 @@ export enum StatusSource {
   NpmLexicalModelCompiler = "npm-lexical-model-compiler",
   NpmModelsTypes = "npm-models-types",
   SKeymanCom = "s-keyman-com",
-  PackagesSilOrg = "packages-sil-org"
+  PackagesSilOrg = "packages-sil-org",
+  LinuxLsdevSilOrgAlpha = "linux-lsdev-sil-org-alpha",
+  LinuxLsdevSilOrgBeta = "linux-lsdev-sil-org-beta",
+  LinuxLsdevSilOrgStable = "linux-lsdev-sil-org-stable"
 };
 


### PR DESCRIPTION
This change adds the deployment status for Launchpad and llso for beta and alpha builds. It also adds llso to stable builds.