### PR TITLE
fix: version number extraction on pso and llso

### DIFF
--- a/server/services/deployment/linux-lsdev-sil-org.ts
+++ b/server/services/deployment/linux-lsdev-sil-org.ts
@@ -9,6 +9,14 @@ Source: keyman-config (14.0.273-1)
 Version: 14.0.273-1+focal1
 ```
 
+or:
+
+```
+Package: keyman
+Source: keyman-config
+Version: 14.0.273-1+focal1
+```
+
 */
 
 import httpget from "../../util/httpget";
@@ -22,7 +30,7 @@ const PATH_SUFFIX='/main/binary-amd64/Packages';
 const service = {
    get: function(llsoTier: string) {
     return httpget(HOST, PATH_PREFIX+llsoTier+PATH_SUFFIX, null, false, true).then((data) => {
-      const results = data.data.match(/^Package: keyman\s*\nSource:\s*keyman-config \((\d+\.\d+\.\d+)-\d+\)/m);
+      const results = data.data.match(/^Package: keyman\s*\nSource:\s*keyman-config[^\n]*\nVersion: (\d+\.\d+\.\d+)-\d+/m);
       if(results) {
         return { version: results[1] };
       }

--- a/server/services/deployment/packages-sil-org.ts
+++ b/server/services/deployment/packages-sil-org.ts
@@ -8,6 +8,14 @@ Source: keyman-config (14.0.273-1)
 Version: 14.0.273-1+focal1
 ```
 
+or:
+
+```
+Package: keyman
+Source: keyman-config
+Version: 14.0.273-1+focal1
+```
+
 */
 
 import httpget from "../../util/httpget";
@@ -20,7 +28,7 @@ const PATH='/ubuntu/dists/focal/main/binary-amd64/Packages';
 const service: DataService = {
    get: function() {
     return httpget(HOST, PATH).then((data) => {
-      const results = data.data.match(/^Package: keyman\s*\nSource:\s*keyman-config \((\d+\.\d+\.\d+)-\d+\)/m);
+      const results = data.data.match(/^Package: keyman\s*\nSource:\s*keyman-config[^\n]*\nVersion: (\d+\.\d+\.\d+)-\d+/m);
       if(results) {
         return { version: results[1] };
       }


### PR DESCRIPTION
The source package isn't always listed with a version number on pso and llso. This change uses the `Version` field instead to
retrieve the version number. This gives the version of the binary package - which should be identical to the version of the source
package.