### PR TITLE
fix: handle site failures with catch

### DIFF
--- a/public/angular.json
+++ b/public/angular.json
@@ -40,7 +40,7 @@
               ],
               "optimization": true,
               "outputHashing": "all",
-              "sourceMap": false,
+              "sourceMap": true,
               "extractCss": true,
               "namedChunks": false,
               "extractLicenses": true,

--- a/server/code.ts
+++ b/server/code.ts
@@ -95,7 +95,9 @@ wsServer.on('connection', socket => {
 });
 
 function respondKeymanDataChange() {
-  statusData.refreshKeymanVersionData().then(hasChanged => sendWsAlert(hasChanged, 'keyman'));
+  return statusData.refreshKeymanVersionData()
+    .then(hasChanged => sendWsAlert(hasChanged, 'keyman'))
+    .catch(error => console.log(error));
 }
 
 function respondGitHubDataChange() {
@@ -105,19 +107,24 @@ function respondGitHubDataChange() {
 
   timingManager.start('github');
 
-  return statusData.refreshGitHubStatusData('current').
-    then(hasChanged => sendWsAlert(hasChanged, 'github')).
-    then(respondGitHubContributionsDataChange).
-    then(respondGitHubIssuesDataChange).
-    finally(() => timingManager.finish('github'));
+  return statusData.refreshGitHubStatusData('current')
+    .then(hasChanged => sendWsAlert(hasChanged, 'github'))
+    .then(respondGitHubContributionsDataChange)
+    .then(respondGitHubIssuesDataChange)
+    .catch(error => console.error(error))
+    .finally(() => timingManager.finish('github'));
 }
 
 function respondGitHubIssuesDataChange() {
-  return statusData.refreshGitHubIssuesData().then(hasChanged => sendWsAlert(hasChanged, 'github-issues'));
+  return statusData.refreshGitHubIssuesData()
+    .then(hasChanged => sendWsAlert(hasChanged, 'github-issues'))
+    .catch(error => console.log(error));
 }
 
 function respondGitHubContributionsDataChange() {
-  statusData.refreshGitHubContributionsData('current').then(hasChanged => sendWsAlert(hasChanged, 'github-contributions'));
+  return statusData.refreshGitHubContributionsData('current')
+    .then(hasChanged => sendWsAlert(hasChanged, 'github-contributions'))
+    .catch(error => console.log(error));
 }
 
 function respondTeamcityDataChange() {
@@ -126,9 +133,10 @@ function respondTeamcityDataChange() {
   }
 
   timingManager.start('teamcity');
-  statusData.refreshTeamcityData().
-    then(hasChanged => sendWsAlert(hasChanged, 'teamcity')).
-    finally(() => timingManager.finish('teamcity'));
+  return statusData.refreshTeamcityData()
+    .then(hasChanged => sendWsAlert(hasChanged, 'teamcity'))
+    .catch(error => console.error(error))
+    .finally(() => timingManager.finish('teamcity'));
 }
 
 function respondSentryDataChange() {
@@ -138,9 +146,10 @@ function respondSentryDataChange() {
 
   timingManager.start('sentry');
 
-  statusData.refreshSentryIssuesData().
-    then(hasChanged => sendWsAlert(hasChanged, 'sentry-issues')).
-    finally(() => timingManager.finish('sentry'));
+  return statusData.refreshSentryIssuesData()
+    .then(hasChanged => sendWsAlert(hasChanged, 'sentry-issues'))
+    .catch(error => console.error(error))
+    .finally(() => timingManager.finish('sentry'));
 }
 
 function respondPolledEndpoints() {

--- a/server/util/httpget.ts
+++ b/server/util/httpget.ts
@@ -4,7 +4,7 @@ import * as http from "http";
 type resolver = (a: {data: string; res: http.IncomingMessage}) => void;
 
 export default function httpget(hostname, path, headers?, head?: boolean, httpOnly?: boolean) {
-  return new Promise((resolve: resolver) => {
+  return new Promise((resolve: resolver, reject) => {
     const options: https.RequestOptions = {
       hostname: hostname,
       port: httpOnly ? 80 : 443,
@@ -31,7 +31,7 @@ export default function httpget(hostname, path, headers?, head?: boolean, httpOn
     });
 
     req.on('error', error => {
-      console.error(error);
+      reject(error);
     });
 
     req.end();


### PR DESCRIPTION
We did not catch failures correctly so if a timed site call resulted in failure, we'd never reset the timer.

Also, enables source maps for angular so we get better errors