### PR TITLE
fix: download links

### DIFF
--- a/public/src/app/deploy-box/deploy-box.component.html
+++ b/public/src/app/deploy-box/deploy-box.component.html
@@ -1,6 +1,6 @@
 <div class="tier-release {{pinned ? 'pinned' : ''}}">
   <div class="tier-release-version {{getDownloadClass()}}">
-    <a href="{{status?.keyman[platform.value.id]?.stable.downloadUrl}}" target="_blank">v</a>
+    <a href="{{targets[0].url}}" target="_blank">v</a>
   </div>
 
   <!-- target deployment platforms -->


### PR DESCRIPTION
Previously we always showed the link to the stable download as link
under the deploy box.