### PR TITLE
fix: More adjustments for consolidated Debian package

### DIFF
--- a/public/src/app/app.component.ts
+++ b/public/src/app/app.component.ts
@@ -320,7 +320,8 @@ export class AppComponent {
     if(!data) return result;
     Object.keys(data).forEach(environment => {
       data[environment].forEach(issue => {
-        if(!issue) return;
+        if (!issue) return;
+        if (!issue.project) return;
         let platformName = siteSentryNames[issue.project.slug] ?
           siteSentryNames[issue.project.slug] :
           this.getPlatformFromSentryProject(issue.project.slug);

--- a/public/src/app/deploy-box/deploy-box.component.ts
+++ b/public/src/app/deploy-box/deploy-box.component.ts
@@ -93,7 +93,7 @@ export class DeployBoxComponent implements OnInit, OnChanges {
             date: this.status?.deployment?.[`launch-pad-${this.tier}`]?.date_published.substr(0, 10)
           }, {
             name: 'linux.lsdev.sil.org',
-            url: 'http://linux.lsdev.sil.org/ubuntu/pool/main/k/keyman-config/',
+            url: 'http://linux.lsdev.sil.org/ubuntu/pool/main/k/keyman/',
             version: this.status?.deployment?.[`linux-lsdev-sil-org-${this.tier}`]?.version
           });
         }

--- a/server/services/deployment/linux-lsdev-sil-org.ts
+++ b/server/services/deployment/linux-lsdev-sil-org.ts
@@ -17,6 +17,13 @@ Source: keyman-config
 Version: 14.0.273-1+focal1
 ```
 
+or:
+
+```
+Package: keyman
+Version: 15.0.100-1+focal1
+```
+
 */
 
 import httpget from "../../util/httpget";
@@ -30,9 +37,9 @@ const PATH_SUFFIX='/main/binary-amd64/Packages';
 const service = {
    get: function(llsoTier: string) {
     return httpget(HOST, PATH_PREFIX+llsoTier+PATH_SUFFIX, null, false, true).then((data) => {
-      const results = data.data.match(/^Package: keyman\s*\nSource:\s*keyman[^\n]*\nVersion: (\d+\.\d+\.\d+)-\d+/m);
+      const results = data.data.match(/^Package: keyman\s*\n(Source:\s*keyman[^\n]*\n)?Version: (\d+\.\d+\.\d+)-\d+/m);
       if(results) {
-        return { version: results[1] };
+        return { version: results[2] };
       }
 
       return null;


### PR DESCRIPTION
The previous fix (#145) missed the fact that if the package name equals the source package name the latter will be omitted. Also
the URL changed.