### PR TITLE
fix: Allow to build server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-## Quick Start ##
+# Quick Start
 
 Clone the repo:
 
-```
+```bash
 git clone https://github.com/keymanapp/status.keyman.com
 cd status.keyman.com/
 ```
 
 Build status.keyman.com:
 
-```
+```bash
 cd server
 npm install
 npm run-script build
@@ -21,7 +21,7 @@ cd ..
 
 Before running the node server, you need to have two API tokens set as environment variables.  You might want to add these to script `server/localenv.sh`.
 
-```
+```bash
 export KEYMANSTATUS_TEAMCITY_TOKEN=[your personal auth token here]
 export KEYMANSTATUS_GITHUB_TOKEN=[your personal auth token here]
 export KEYMANSTATUS_SENTRY_TOKEN=[your personal auth token here]
@@ -29,20 +29,20 @@ export KEYMANSTATUS_SENTRY_TOKEN=[your personal auth token here]
 
 On Windows, you'll also need to have Git Bash installed in `C:\Program Files\git\bin\bash.exe`.
 
-## Development server ##
+## Development server
 
 This repo is configured for live build and reload of both the client and server. You'll need two terminals open. In the first, run:
 
-```
+```bash
 npm run start-server
 ```
 
 and in the second, run:
 
-```
+```bash
 npm run start-client
 ```
 
-* Point your browser to `http://localhost:4200` to view the live reload version of the application.
+* Point your browser to <http://localhost:4200> to view the live reload version of the application.
 * The query parameter `?c=1` adds a contributions view which is not visible by default.
 * Another query parameter `?sprint=P8S4` parameter to view sprint contributions data for P8S4

--- a/server/package.json
+++ b/server/package.json
@@ -27,6 +27,7 @@
     "@octokit/types": "^6.25.0",
     "@types/deep-equal": "^1.0.1",
     "@types/express": "^4.17.11",
+    "@types/jest": "^27.0.1",
     "@types/node": "^16.7.1",
     "@types/parse-link-header": "^1.0.0",
     "@typescript-eslint/eslint-plugin": "^4.18.0",


### PR DESCRIPTION
Without this change building fails because tsc doesn't know `describe` and `it`.