### PR TITLE
fix: persist popups

### DIFF
--- a/public/src/app/app.module.ts
+++ b/public/src/app/app.module.ts
@@ -13,6 +13,7 @@ import { ClipboardComponent } from './clipboard/clipboard.component';
 import { DeployBoxComponent } from './deploy-box/deploy-box.component';
 import { ManualTestComponent } from './manual-test/manual-test.component';
 import { HomeComponent } from './home/home.component';
+import { PopupComponent } from './popup/popup.component';
 
 @NgModule({
   declarations: [
@@ -26,6 +27,7 @@ import { HomeComponent } from './home/home.component';
     DeployBoxComponent,
     ManualTestComponent,
     HomeComponent,
+    PopupComponent,
   ],
   imports: [
     BrowserModule,

--- a/public/src/app/deploy-box/deploy-box.component.ts
+++ b/public/src/app/deploy-box/deploy-box.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit, OnChanges, Input } from '@angular/core';
 import { StatusSource } from '../../../../shared/status-source';
 import { compare as versionCompare } from "compare-versions";
+import { PopupComponent } from '../popup/popup.component';
 
 interface DeployTarget {
   name: string;
@@ -14,27 +15,23 @@ interface DeployTarget {
   templateUrl: './deploy-box.component.html',
   styleUrls: ['./deploy-box.component.css']
 })
-export class DeployBoxComponent implements OnInit, OnChanges {
+export class DeployBoxComponent extends PopupComponent implements OnInit, OnChanges {
   @Input() tier: string;
   @Input() platform: any;
   @Input() status: any;
   @Input() downloadClass: string;
   @Input() builtVersion: string;
   @Input() releaseDate: string;
-  @Input() gravityX?: string;
-  @Input() gravityY?: string;
   @Input() changeCounter: number;
-
-  pinned: boolean = false;
 
   targets: DeployTarget[] = [];
 
-  constructor() { }
-
   ngOnInit() {
+    this.popupId = 'deploy-box-'+this.platform?.value?.id+'-'+this.tier;
     if(!this.gravityX) this.gravityX = 'right';
     if(!this.gravityY) this.gravityY = 'bottom';
     this.prepareData();
+    super.ngOnInit();
   }
 
   ngOnChanges() {
@@ -121,10 +118,6 @@ export class DeployBoxComponent implements OnInit, OnChanges {
         });
         break;
     }
-  }
-
-  pin() {
-    this.pinned = !this.pinned;
   }
 
   getLatestKeymanWebFromSKeymanCom(version: string) {

--- a/public/src/app/home/home.component.html
+++ b/public/src/app/home/home.component.html
@@ -182,7 +182,7 @@
             <div [class]="'emoji-group' + (emoji.key == '' ? '' : ' emoji-group-border')" *ngFor="let emoji of platform.value.pullsByEmoji | keyvalue">
               <span *ngIf="emoji.key != ''" class="emoji">{{emoji.key}}</span>
               <span *ngFor="let pull of emoji.value">
-                <app-pull-request [scope]="'platform'" [gravityX]="'left'" [gravityY]="'bottom'" [pull]="pull"></app-pull-request>
+                <app-pull-request [scope]="'platform'" [scopeValue]="platform.value.id" [gravityX]="'left'" [gravityY]="'bottom'" [pull]="pull"></app-pull-request>
               </span>
               </div>
           </td>

--- a/public/src/app/issue-list/issue-list.component.ts
+++ b/public/src/app/issue-list/issue-list.component.ts
@@ -3,32 +3,30 @@ import { DomSanitizer } from '@angular/platform-browser';
 import { repoShortNameFromGithubUrl } from '../utility/repoShortNameFromGithubUrl';
 import { escapeHtml } from '../utility/escapeHtml';
 import { labelColor } from '../utility/labelColor';
+import { PopupCoordinatorService } from '../popup-coordinator.service';
+import { PopupComponent } from '../popup/popup.component';
 
 @Component({
   selector: 'app-issue-list',
   templateUrl: './issue-list.component.html',
   styleUrls: ['./issue-list.component.css']
 })
-export class IssueListComponent implements OnInit {
+export class IssueListComponent extends PopupComponent implements OnInit {
   @Input() isNav: boolean;
   @Input() issues: any;
   @Input() repo?: any;
   @Input() milestone?: any;
   @Input() platform?: any;
-  @Input() gravityX?: string;
-  @Input() gravityY?: string;
 
-  constructor(private sanitizer: DomSanitizer) { }
-
-  pinned: boolean = false;
-
-  ngOnInit() {
-    if(!this.gravityX) this.gravityX = 'right';
-    if(!this.gravityY) this.gravityY = 'bottom';
+  constructor(private sanitizer: DomSanitizer, popupCoordinator: PopupCoordinatorService) {
+    super(popupCoordinator);
   }
 
-  pin() {
-    this.pinned = !this.pinned;
+  ngOnInit() {
+    this.popupId = 'issues-'+(this.platform ? this.platform.value.id : this.repo)+'-'+this.milestone?.title;
+    if(!this.gravityX) this.gravityX = 'right';
+    if(!this.gravityY) this.gravityY = 'bottom';
+    super.ngOnInit();
   }
 
   labelColor(label) {

--- a/public/src/app/popup-coordinator.service.ts
+++ b/public/src/app/popup-coordinator.service.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@angular/core';
+
+class PopupData {
+  id: string;
+  pinned: boolean;
+  hover: boolean;
+};
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PopupCoordinatorService {
+
+  popups: {[id: string]: PopupData};
+
+  constructor() {
+    this.popups = {};
+  }
+
+  addPopup(id: string) {
+    let data = this.popups[id];
+    if(typeof data == 'undefined') {
+      this.popups[id] = {
+        id: id,
+        pinned: false,
+        hover: false
+      };
+    }
+  }
+
+  isPinned(id: string) {
+    return this.popups[id] && this.popups[id].pinned;
+  }
+
+  togglePin(id: string) {
+    if(this.popups[id]) {
+      this.popups[id].pinned = !this.popups[id].pinned;
+    }
+  }
+}

--- a/public/src/app/popup/popup.component.ts
+++ b/public/src/app/popup/popup.component.ts
@@ -1,0 +1,30 @@
+import { Component, OnInit, Input } from '@angular/core';
+import { PopupCoordinatorService } from '../popup-coordinator.service';
+
+@Component({
+  selector: 'app-popup',
+  template: ``,
+  styleUrls: ['./popup.component.css']
+})
+export class PopupComponent implements OnInit {
+  @Input() gravityX?: string;
+  @Input() gravityY?: string;
+
+  popupId: string;
+
+  get pinned(): boolean {
+    return this.popupCoordinator.isPinned(this.popupId);
+  }
+
+  constructor(private popupCoordinator: PopupCoordinatorService) { }
+
+  ngOnInit(): void {
+    this.popupCoordinator.addPopup(this.popupId);
+    if(!this.gravityX) this.gravityX = 'left';
+    if(!this.gravityY) this.gravityY = 'bottom';
+  }
+
+  pin() {
+    this.popupCoordinator.togglePin(this.popupId);
+  }
+}

--- a/public/src/app/pull-request/pull-request.component.ts
+++ b/public/src/app/pull-request/pull-request.component.ts
@@ -2,26 +2,27 @@ import { Component, OnInit, Input } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
 import { labelColor } from '../utility/labelColor';
 import emojiRegex from 'emoji-regex/es2015/RGI_Emoji';
+import { PopupComponent } from '../popup/popup.component';
+import { PopupCoordinatorService } from '../popup-coordinator.service';
 
 @Component({
   selector: 'app-pull-request',
   templateUrl: './pull-request.component.html',
   styleUrls: ['./pull-request.component.css']
 })
-export class PullRequestComponent implements OnInit {
+export class PullRequestComponent extends PopupComponent implements OnInit {
   @Input() pull: any;
   @Input() class?: string;
-  @Input() gravityX?: string;
-  @Input() gravityY?: string;
   @Input() scope?: string;
+  @Input() scopeValue?: string;
 
-  pinned: boolean = false;
-
-  constructor(private sanitizer: DomSanitizer) { }
+  constructor(private sanitizer: DomSanitizer, popupCoordinator: PopupCoordinatorService) { super(popupCoordinator); }
 
   ngOnInit() {
+    this.popupId = 'pull-'+this.pull.pull.node.number+(this.scopeValue ? '-'+this.scopeValue:'');
     if(!this.gravityX) this.gravityX = 'right';
     if(!this.gravityY) this.gravityY = 'bottom';
+    super.ngOnInit();
   }
 
   pullClass() {
@@ -132,9 +133,5 @@ export class PullRequestComponent implements OnInit {
 
   labelName(label: string) {
     return label.replace(/-/g, '‑');
-  }
-
-  pin() {
-    this.pinned = !this.pinned;
   }
 }

--- a/public/src/app/sentry/sentry.component.ts
+++ b/public/src/app/sentry/sentry.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit, OnChanges, Input } from '@angular/core';
+import { PopupComponent } from '../popup/popup.component';
 import { siteSentryIds } from '../sites';
 import { escapeHtml } from '../utility/escapeHtml';
 
@@ -7,22 +8,17 @@ import { escapeHtml } from '../utility/escapeHtml';
   templateUrl: './sentry.component.html',
   styleUrls: ['./sentry.component.css']
 })
-export class SentryComponent implements OnInit, OnChanges {
+export class SentryComponent extends PopupComponent implements OnInit, OnChanges {
   @Input() environment: string;
   @Input() platform?: string;
   @Input() site?: string;
   @Input() issues?: any;
-  @Input() gravityX?: string;
-  @Input() gravityY?: string;
   @Input() mode?: string;
-
-  pinned: boolean = false;
 
   env: any;
 
-  constructor() { }
-
   ngOnInit() {
+    this.popupId = 'sentry-'+this.environment+'-'+(this.platform ? this.platform : this.site);
     if(!this.gravityX) this.gravityX = 'right';
     if(!this.gravityY) this.gravityY = 'bottom';
     this.env = this.issues && this.issues[this.environment] ? this.issues[this.environment] : {
@@ -30,6 +26,7 @@ export class SentryComponent implements OnInit, OnChanges {
       totalEvents: 0,
       issues: []
     };
+    super.ngOnInit();
   }
 
   ngOnChanges() {
@@ -67,10 +64,6 @@ export class SentryComponent implements OnInit, OnChanges {
     const res = /<a href=".+\/(\d+)">/.exec(annotation);
     if(res) return res[1];
     return '';
-  }
-
-  pin() {
-    this.pinned = !this.pinned;
   }
 
   getSentryIssueText() {


### PR DESCRIPTION
Popups would not pin over data changes as they would be reconstructed. This refactor pulls out the common pinning code into a PopupComponent, and adds a PopupCoordinatorService to track the pin state of popups. This is also groundwork for future consolidation of popup common functionality, css, etc.