### PR TITLE
chore: sentry.io reporting 👮‍♂️

### DIFF
--- a/public/src/app/platforms.ts
+++ b/public/src/app/platforms.ts
@@ -67,3 +67,14 @@ export const platforms: PlatformSpec[] = [
     context: "Common"
   },
 ];
+
+// TODO: consolidate with list in sentry-issues.ts
+export const platformSentryIds = {
+  android:   5983520,
+  developer: 5983519,
+  ios:       5983521,
+  linux:     5983525,
+  mac:       5983522,
+  web:       5983524,
+  windows:   5983518
+};

--- a/public/src/app/sentry/sentry.component.html
+++ b/public/src/app/sentry/sentry.component.html
@@ -2,8 +2,8 @@
 
   <span class="label">
     <!--<img class="avatar-22" src="assets/{{platform}}.png" *ngIf="!site && mode != 'simple'">-->
-    <span class="issue-total {{env.issues.length == 0 ? 'normal' : 'error'}}"><a href="https://sentry.keyman.com/organizations/keyman/issues/?project={{projectIndex()}}" target="_blank">{{env.issues.length}}</a></span>
-    <span class="event-total {{env.issues.length == 0 ? 'normal' : 'error'}}" *ngIf="mode != 'simple'"><a href="https://sentry.keyman.com/organizations/keyman/issues/?project={{projectIndex()}}" target="_blank">{{env.totalEvents}}</a></span>
+    <span class="issue-total {{env.issues.length == 0 ? 'normal' : 'error'}}"><a href="https://sentry.io/organizations/keyman/issues/?project={{projectIndex()}}" target="_blank">{{env.issues.length}}</a></span>
+    <span class="event-total {{env.issues.length == 0 ? 'normal' : 'error'}}" *ngIf="mode != 'simple'"><a href="https://sentry.io/organizations/keyman/issues/?project={{projectIndex()}}" target="_blank">{{env.totalEvents}}</a></span>
   </span>
 
   <div class="sentry-detail {{pinned ? 'pinned':''}} gravity-{{gravityX}} gravity-{{gravityY}}">

--- a/public/src/app/sentry/sentry.component.ts
+++ b/public/src/app/sentry/sentry.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit, OnChanges, Input } from '@angular/core';
+import { platformSentryIds } from '../platforms';
 import { PopupComponent } from '../popup/popup.component';
 import { siteSentryIds } from '../sites';
 import { escapeHtml } from '../utility/escapeHtml';
@@ -39,17 +40,7 @@ export class SentryComponent extends PopupComponent implements OnInit, OnChanges
 
   projectIndex(): number {
     if(!this.platform) return 0;
-    // TODO: consolidate with list in code.js
-    const map = { ...siteSentryIds, ...{
-      android:7,
-      developer:6,
-      ios:8,
-      linux:12,
-      mac:9,
-      web:11,
-      windows:5
-      }
-    };
+    const map = { ...siteSentryIds, ...platformSentryIds };
     return map[this.platform];
   }
 

--- a/public/src/app/sites.ts
+++ b/public/src/app/sites.ts
@@ -11,16 +11,17 @@ export const sites = [
 ];
 
 // TODO: this could be consolidated above
+// TODO: consolidate with list in sentry-issues.ts
 export const siteSentryIds = {
-  'api.keyman.com': 4,
-  'developer.keyman.com': 14,
-  'donate.keyman.com': 15,
-  'downloads.keyman.com': 16,
-  'help.keyman.com': 2,
-  'keyman.com': 3,
-  'keymanweb.com': 10,
-  's.keyman.com': 17,
-  'status.keyman.com': 13
+  'api.keyman.com': 5983517,
+  'developer.keyman.com': 5983527,
+  'donate.keyman.com': 5983528,
+  'downloads.keyman.com': 5983529,
+  'help.keyman.com': 5983515,
+  'keyman.com': 5983516,
+  'keymanweb.com': 5983523,
+  's.keyman.com': 5983530,
+  'status.keyman.com': 5983526
 };
 
 export const siteSentryNames = {

--- a/public/src/main.ts
+++ b/public/src/main.ts
@@ -7,7 +7,7 @@ import { environment } from './environments/environment';
 import * as Sentry from "@sentry/angular";
 
 Sentry.init({
-  dsn: "https://4ed13a2db1294bb695765ebe2f98171d@sentry.keyman.com/13",
+  dsn: "https://4ed13a2db1294bb695765ebe2f98171d@o1005580.ingest.sentry.io/5983526",
   environment: environment.production ? 'production' : 'development'
 });
 

--- a/server/code.ts
+++ b/server/code.ts
@@ -80,6 +80,9 @@ setInterval(() => {
     // NOTE: using polling in production as webhook stopped working on 6 July 2021?
     // We have a webhook running on production so no need to poll the server
     respondTeamcityDataChange();
+    // NOTE: adding sentry polling here as we don't get events on errors on our
+    // current plan with sentry.io
+    respondSentryDataChange();
   }
 }, REFRESH_INTERVAL);
 
@@ -206,6 +209,14 @@ app.post('/webhook/teamcity', (request, response) => {
 });
 
 app.post('/webhook/sentry', (request, response) => {
+  // TODO: use the webhook data returned from sentry to refresh only the
+  //       affected project, as returned in request.body.data.issue.project.
+  //       This will be easier to implement if we refactor the sentry data to
+  //       group by project instead of by environment. (History, we grouped) by
+  //       environment originally because we were able to do 1 query per env
+  //       rather than per-project, but on sentry.io we don't have perms to do
+  //       the org-wide query at this time.
+  //console.log('webhook sentry project='+request.body?.data?.issue?.project?.id);
   respondSentryDataChange();
   response.send('ok');
 });

--- a/server/services/sentry/sentry-issues.ts
+++ b/server/services/sentry/sentry-issues.ts
@@ -116,7 +116,7 @@ export default {
         const link = typeof data.res.headers.link == 'string' ? data.res.headers.link : data.res.headers.link[0];
         const links = parseLinkHeader(link);
         if(links && links.next && links.next.results == 'true') {
-          return this.delay().then(() => { this.getEnvironment(environment, project, links.next.cursor, results) });
+          return this.delay().then(() => this.getEnvironment(environment, project, links.next.cursor, results));
         }
       }
       return results;

--- a/server/services/sentry/sentry-issues.ts
+++ b/server/services/sentry/sentry-issues.ts
@@ -1,5 +1,5 @@
 /*
- Service to collect stats from sentry.keyman.com
+ Service to collect stats from sentry.io (formerly sentry.keyman.com)
 */
 
 import httpget from "../../util/httpget";
@@ -9,17 +9,76 @@ const sentry_token=process.env['KEYMANSTATUS_SENTRY_TOKEN'];
 
 export default {
   get: async function() {
-    let environments = ['alpha', 'beta', 'stable', /*'local', 'development',*/ 'production', /*'staging', 'test'*/];
+    let appEnvironments = ['alpha', 'beta', 'stable', /*'local'*/];
+    let siteEnvironments = [/*'development',*/ 'production', /*'staging', 'test'*/];
     let result = {};
-    for(let environment of environments) {
-      result[environment] = await this.getEnvironment(environment);
+    for(let environment of appEnvironments) {
+      result[environment] = await this.getEnvironment(true, environment);
+    }
+    for(let environment of siteEnvironments) {
+      result[environment] = await this.getEnvironment(false, environment);
     }
     return result;
   },
 
-  getEnvironment: function(environment, cursor?, issues?) {
+  getEnvironment: async function(isApp, environment) {
+    const appProjects = [
+      5983532, // fv-android
+      5983531, // kab-android
+      5983525, // keyman-linux
+      5983524, // keyman-web
+      5983522, // keyman-mac
+      5983521, // keyman-ios
+      5983520, // keyman-android
+      5983519, // keyman-developer
+      5983518, // keyman-windows
+    ];
 
-// https://sentry.keyman.com/api/0/organizations/keyman/issues/
+    const siteProjects = [
+      5983530, // s-keyman-com
+      5983529, // downloads-keyman-com
+      5983528, // donate-keyman-com
+      5983527, // developer-keyman-com
+      5983526, // status-keyman-com
+      5983523, // keymanweb-com
+      5983517, // api-keyman-com
+      5983516, // keyman-com
+      5983515, // help-keyman-com
+    ];
+
+    const projects = isApp ? appProjects : siteProjects;
+
+    return projects.reduce((previousPromise, project) => {
+      return previousPromise.then((results) => {
+        // We cannot do more than 10 requests/second. Given we cannot do
+        // cross-project requests on our current plan, nor get environment data
+        // in the returned issue data, we have to issue multiple requests, one
+        // per project per environment, and we'll delay each one by 125msec to
+        // guarantee we don't exceed our quota. This means (9 app projects * 3 +
+        // 9 site projects * 1 env) = 36 requests minimum, approximately 4.5
+        // seconds of delay, plus response time. If we have >100 issues in any
+        // given project, that will increase the response time as we delay
+        // paginated responses also.
+        return this.delay().then(() => {
+          return this.getEnvironmentProject(environment, project).then(data => {
+            return [].concat(results, data);
+          });
+        })
+      })
+    },
+      Promise.resolve<[]>([])
+    );
+  },
+
+  delay() {
+    return new Promise<void>(function(resolve, reject) {
+      setTimeout(resolve, 125);
+    });
+  },
+
+  getEnvironmentProject: function(environment, project, cursor?, issues?) {
+
+// https://sentry.io/api/0/organizations/keyman/issues/
 // end=2021-03-24T12%3A59%3A59
 // or statsPeriod=14d
 // groupStatsPeriod=auto
@@ -34,28 +93,30 @@ export default {
       `/api/0/organizations/keyman/issues/`+
       `?statsPeriod=14d`+
       `&groupStatsPeriod=auto`+
+      `&project=${project}`+
       `&shortIdLookup=1`+
       `&sort=freq`+
       `&utc=false`+
       `&limit=100`+
       `&query=is%3Aunresolved`+
-      `&environment=${environment}`+
+      `+environment%3A${environment}`+ // note, it seems `&environment= doesn't work on sentry.io, but query=environment: does?
       (cursor ? `&cursor=${cursor}` : ``);
     const authOptions = {
       Authorization: ` Bearer ${sentry_token}`,
       Accept: 'application/json'
     };
-    const host = 'sentry.keyman.com';
+    const host = 'sentry.io';
 
     let sentryQuery = httpget(host, url, authOptions);
 
     return sentryQuery.then((data) => {
+      //console.log(data.data);
       let results = [].concat(issues, JSON.parse(data.data));
       if(data.res.headers.link) {
         const link = typeof data.res.headers.link == 'string' ? data.res.headers.link : data.res.headers.link[0];
         const links = parseLinkHeader(link);
         if(links && links.next && links.next.results == 'true') {
-          return this.getEnvironment(environment, links.next.cursor, results);
+          return this.delay().then(() => { this.getEnvironment(environment, project, links.next.cursor, results) });
         }
       }
       return results;


### PR DESCRIPTION
This ended up being a bit of a yak shave. Had to rewrite the sentry issue data service because we can't do cross-project querying on our current sentry.io sponsored plan. In order to avoid hitting rate limits, we have to also delay the 36+ requests by 125msec each.

As our current plan also does not give us webhook notifications for new errors, only for new issues, we now poll the sentry endpoint along with all our other polling.