### PR TITLE
fix: bot test match improvements

### DIFF
--- a/public/src/app/home/home.component.ts
+++ b/public/src/app/home/home.component.ts
@@ -738,6 +738,10 @@ export class HomeComponent {
         case 'user-test-failure':
           if(!this.pullsByStatus.waitingResponse.includes(pd))
             this.pullsByStatus.waitingResponse.push(pd);
+
+          if(pull.node.labels.edges.find(e => e.node.name == 'user-test-required')) {
+            this.pullsByStatus.waitingTest.push(pd);
+          }
           break;
         case 'user-test-pending':
           this.pullsByStatus.waitingTest.push(pd);

--- a/shared/manual-test/manual-test-parser.ts
+++ b/shared/manual-test/manual-test-parser.ts
@@ -259,16 +259,13 @@ export default class ManualTestParser {
       if(match.match(/^SUITE_/i)) {
         suite = protocol.findSuite(match.substring(6));
       } else if(match.match(/^GROUP_/i)) {
-        group = (suite || protocol.suites[0]).findGroup(match.substring(6));
+        group = (suite || protocol).findGroup(match.substring(6));
       } else if(match.match(/^TEST_/i)) {
-        let test = (group || protocol).findTest(match.substring(5));
-        if(test) {
+        for(let test of (group || suite || protocol).findTests(match.substring(5))) {
           test.addRun(id, true, ManualTestStatus.Open);
         }
       } else if(match == 'all') {
-        for(let test of (group ? group.tests :
-            suite ? suite.getTests() :
-            protocol.getTests())) {
+        for(let test of (group || suite || protocol).getTests()) {
           test.addRun(id, true, ManualTestStatus.Open);
         }
       }

--- a/shared/manual-test/manual-test-protocols.ts
+++ b/shared/manual-test/manual-test-protocols.ts
@@ -134,6 +134,14 @@ export class ManualTestGroup {
     return ManualTestStatusUtil.emoji(this.status());
   }
 
+  findTests(name: string): ManualTest[] {
+    return this.tests.filter(test => test.name.toLowerCase() == name.toLowerCase());
+  }
+
+  getTests(): ManualTest[] {
+    return this.tests;
+  }
+
   tests: ManualTest[];
   constructor() {
     this.tests = [];
@@ -157,6 +165,10 @@ export class ManualTestSuite {
 
   getTests(): ManualTest[] {
     return this.groups.flatMap(group => group.tests);
+  }
+
+  findTests(name: string): ManualTest[] {
+    return this.getTests().filter(test => test.name.toLowerCase() == name.toLowerCase());
   }
 
   statusEmoji(): string {
@@ -192,14 +204,51 @@ export class ManualTestProtocol {
   userTestResults: ManualTestComment;
   suites: ManualTestSuite[];
 
+  /**
+   * @returns flat array of all tests in all groups in all suites
+   */
   getTests(): ManualTest[] {
     return this.suites.flatMap(suite => suite.groups.flatMap(group => group.tests));
   }
 
+  /**
+   * @returns flat array of all groups in all suites
+   */
+  getGroups(): ManualTestGroup[] {
+    return this.suites.flatMap(suite => suite.groups);
+  }
+
+  /**
+   * Finds first test that matches `name` in all suites and groups
+   */
   findTest(name: string): ManualTest {
     return this.getTests().find(test => test.name.toLowerCase() == name.toLowerCase());
   }
 
+  /**
+   * Finds all tests that match `name` in all suites and groups
+   */
+  findTests(name: string): ManualTest[] {
+    return this.getTests().filter(test => test.name.toLowerCase() == name.toLowerCase());
+  }
+
+  /**
+   * Finds all groups that match `name` in all suites
+   */
+  findGroups(name: string): ManualTestGroup[] {
+    return this.getGroups().filter(group => group.name.toLowerCase() == name.toLowerCase());
+  }
+
+  /**
+   * Finds first group that matches `name` in any suite
+   */
+  findGroup(name: string): ManualTestGroup {
+    return this.suites.flatMap(suite => suite.groups).find(group => group.name.toLowerCase() == name.toLowerCase());
+  }
+
+  /**
+   * Finds first suite that matches `name`
+   */
   findSuite(name: string): ManualTestSuite {
     return this.suites.find(suite => suite.name.toLowerCase() == name.toLowerCase());
   }


### PR DESCRIPTION
* retest clause now matches all tests within a protocol or suite
* awaiting test view will show any PR that has incomplete tests, even if other tests have also failed.