### PR TITLE
fix(testbot): Use different checkmark for passed tests

### DIFF
--- a/server/keymanapp-test-bot/README.md
+++ b/server/keymanapp-test-bot/README.md
@@ -12,7 +12,8 @@
 -6. status of a test in the User Testing comment should be a link to the comment where it is reported
 -13. add a '*' if there are details for a test result
 -5. design how we would run test suites and grouped tests (SUITE / GROUP / TEST)
--   a) consider using emoji for SUITES and GROUPS so we don't confuse with checkboxes ✅ 🟧 🟥 🟩 🟦 🟨 ❎ ❌
+-   a) consider using emoji for SUITES and GROUPS so we don't confuse with checkboxes ✔️ 🟧 🟥 🟩 🟦 🟨 ❎ ❌
+       (Note we use ✔️ instead of ✅ for better visibility on Linux)
 -3. auto PRs will not be tagged by the bot. (either auto label or created by [any] bot)
 -2. icon and metadata for the bot - which orgs can install it, etc.
 -1. Deploy manual-test-bot - PEM, secret, and address.
@@ -85,9 +86,9 @@ First comment (auto-reserved by test-bot):
 * 🟥 GROUP_MACOS: the dot point is optional
   V Tests
     * 🟥 TEST_RESIZING
-    * ✅ TEST_LAYERS_SHIFT
-    * ✅ TEST_LAYERS_CAPS
-* ✅ GROUP_LINUX
+    * ✔️ TEST_LAYERS_SHIFT
+    * ✔️ TEST_LAYERS_CAPS
+* ✔️ GROUP_LINUX
 * ⬜ GROUP_CHROMEBOOK
 ```
 

--- a/server/test/manual-test-parser.spec.ts
+++ b/server/test/manual-test-parser.spec.ts
@@ -81,7 +81,7 @@ const userTestResultsComment =
 
 [Test specification and instructions](https://github.com/keymanapp/keyman/issues/1#issuecomment-1)
 
-- ✅ **TEST_FOO ([PASSED](https://github.com/keymanapp/keyman/issues/1#issuecomment-2))**: yes great ([notes](https://github.com/keymanapp/keyman/issues/1#issuecomment-2))
+- ✔️ **TEST_FOO ([PASSED](https://github.com/keymanapp/keyman/issues/1#issuecomment-2))**: yes great ([notes](https://github.com/keymanapp/keyman/issues/1#issuecomment-2))
 - 🟥 **TEST_BAR ([FAILED](https://github.com/keymanapp/keyman/issues/1#issuecomment-2))** ([notes](https://github.com/keymanapp/keyman/issues/1#issuecomment-2))
 - ⬜ **TEST_FIZZ (OPEN)**
 - ⬜ **TEST_BAZ (OPEN)**`;
@@ -91,10 +91,10 @@ const userTestResultsAllPassedComment =
 
 [Test specification and instructions](https://github.com/keymanapp/keyman/issues/1#issuecomment-1)
 
-- ✅ **TEST_FOO ([PASSED](https://github.com/keymanapp/keyman/issues/1#issuecomment-2))**: yes great ([notes](https://github.com/keymanapp/keyman/issues/1#issuecomment-2))
-- ✅ **TEST_BAR ([PASSED](https://github.com/keymanapp/keyman/issues/1#issuecomment-3))** ([notes](https://github.com/keymanapp/keyman/issues/1#issuecomment-3))
-- ✅ **TEST_FIZZ ([PASSED](https://github.com/keymanapp/keyman/issues/1#issuecomment-4))**: this went pretty well actually
-- ✅ **TEST_BAZ ([PASSED](https://github.com/keymanapp/keyman/issues/1#issuecomment-4))** ([notes](https://github.com/keymanapp/keyman/issues/1#issuecomment-4))`;
+- ✔️ **TEST_FOO ([PASSED](https://github.com/keymanapp/keyman/issues/1#issuecomment-2))**: yes great ([notes](https://github.com/keymanapp/keyman/issues/1#issuecomment-2))
+- ✔️ **TEST_BAR ([PASSED](https://github.com/keymanapp/keyman/issues/1#issuecomment-3))** ([notes](https://github.com/keymanapp/keyman/issues/1#issuecomment-3))
+- ✔️ **TEST_FIZZ ([PASSED](https://github.com/keymanapp/keyman/issues/1#issuecomment-4))**: this went pretty well actually
+- ✔️ **TEST_BAZ ([PASSED](https://github.com/keymanapp/keyman/issues/1#issuecomment-4))** ([notes](https://github.com/keymanapp/keyman/issues/1#issuecomment-4))`;
 
 const nestedUserTest =
 `Follows #5619..

--- a/shared/manual-test/manual-test-protocols.ts
+++ b/shared/manual-test/manual-test-protocols.ts
@@ -27,7 +27,7 @@ export class ManualTestStatusUtil {
     return result || ManualTestStatus.Open;
   }
   public static emoji(status: ManualTestStatus) {
-    const statusEmoji: string[] = ['⬜', '✅', '🟥', '🟧', '🟦'];
+    const statusEmoji: string[] = ['⬜', '✔️', '🟥', '🟧', '🟦'];
     return statusEmoji[status];
   }
 }


### PR DESCRIPTION
The previous emoji used for passed tests was hard to see on Linux. This changes uses a different emoji for passed tests which will be better to see on Linux and will work on other platforms as well.

This changes to use ✔️ instead of ✅.

Fixes #192.