### PR TITLE
feat: add 'SKIPPED' test result type

### DIFF
--- a/server/keymanapp-test-bot/keymanapp-test-bot.ts
+++ b/server/keymanapp-test-bot/keymanapp-test-bot.ts
@@ -105,6 +105,7 @@ async function processEvent(
     statusCounts[ManualTestStatus.Passed] = 0;
     statusCounts[ManualTestStatus.Failed] = 0;
     statusCounts[ManualTestStatus.Blocked] = 0;
+    statusCounts[ManualTestStatus.Skipped] = 0;
     statusCounts[ManualTestStatus.Unknown] = 0;
     for(let test of protocol.getTests()) {
       statusCounts[test.status()]++;
@@ -117,12 +118,13 @@ async function processEvent(
 
       (statusCounts[ManualTestStatus.Failed] ? `${statusCounts[ManualTestStatus.Failed]} failed, ` : '') +
       (statusCounts[ManualTestStatus.Blocked] ? `${statusCounts[ManualTestStatus.Blocked]} blocked, ` : '') +
+      (statusCounts[ManualTestStatus.Skipped] ? `${statusCounts[ManualTestStatus.Skipped]} skipped, ` : '') +
       `${statusCounts[ManualTestStatus.Passed]} test(s) passed of ${totalTests}`;
 
     const state =
       protocol.skipTesting ? 'success' :
       totalTests == 0 ? 'failure' : // no tests defined, this is an error
-      statusCounts[ManualTestStatus.Passed] == totalTests ? 'success' : // all passed
+      statusCounts[ManualTestStatus.Passed] + statusCounts[ManualTestStatus.Skipped] == totalTests ? 'success' : // all passed
       statusCounts[ManualTestStatus.Failed] + statusCounts[ManualTestStatus.Blocked] == 0 ? 'pending' :  // no errors, but testing unfinished
       'failure'; // at least one error
 

--- a/server/test/manual-test-parser.spec.ts
+++ b/server/test/manual-test-parser.spec.ts
@@ -65,6 +65,10 @@ I'm not great at formatting test results.
 - Fantastic!
 `;
 
+const skippedTestRunComment = `
+**TEST_FIZZ: PASSED**
+**TEST_BAZ: SKIPPED**`;
+
 const retestComment = `@keymanapp-test-bot retest test_foo, test_baz`;
 const retestAllComment = `
 I'm not happy with the results
@@ -95,6 +99,16 @@ const userTestResultsAllPassedComment =
 - ✅ **TEST_BAR ([PASSED](https://github.com/keymanapp/keyman/issues/1#issuecomment-3))** ([notes](https://github.com/keymanapp/keyman/issues/1#issuecomment-3))
 - ✅ **TEST_FIZZ ([PASSED](https://github.com/keymanapp/keyman/issues/1#issuecomment-4))**: this went pretty well actually
 - ✅ **TEST_BAZ ([PASSED](https://github.com/keymanapp/keyman/issues/1#issuecomment-4))** ([notes](https://github.com/keymanapp/keyman/issues/1#issuecomment-4))`;
+
+const userTestResultsSkippedComment =
+`# User Test Results
+
+[Test specification and instructions](https://github.com/keymanapp/keyman/issues/1#issuecomment-1)
+
+- ✅ **TEST_FOO ([PASSED](https://github.com/keymanapp/keyman/issues/1#issuecomment-2))**: yes great ([notes](https://github.com/keymanapp/keyman/issues/1#issuecomment-2))
+- ✅ **TEST_BAR ([PASSED](https://github.com/keymanapp/keyman/issues/1#issuecomment-3))** ([notes](https://github.com/keymanapp/keyman/issues/1#issuecomment-3))
+- ✅ **TEST_FIZZ ([PASSED](https://github.com/keymanapp/keyman/issues/1#issuecomment-5))**
+- 🟩 **TEST_BAZ ([SKIPPED](https://github.com/keymanapp/keyman/issues/1#issuecomment-5))**`;
 
 const nestedUserTest =
 `Follows #5619..
@@ -363,16 +377,19 @@ describe('ManualTestParser', function() {
       assert.strictEqual(protocol.getTests()[3].testRuns[0].summary, '');
       assert.strictEqual(protocol.getTests()[3].testRuns[0].notes, '- Fantastic!');
       assert.strictEqual(protocol.getTests()[3].testRuns[0].status, ManualTestStatus.Passed);
-      mtp.parseComment(protocol, 5, retestComment);
+      mtp.parseComment(protocol, 5, skippedTestRunComment);
+      assert.strictEqual(protocol.getTests()[2].status(), ManualTestStatus.Passed);
+      assert.strictEqual(protocol.getTests()[3].status(), ManualTestStatus.Skipped);
+      mtp.parseComment(protocol, 6, retestComment);
       assert.strictEqual(protocol.getTests()[0].status(), ManualTestStatus.Open);
       assert.strictEqual(protocol.getTests()[1].status(), ManualTestStatus.Passed);
       assert.strictEqual(protocol.getTests()[2].status(), ManualTestStatus.Passed);
       assert.strictEqual(protocol.getTests()[3].status(), ManualTestStatus.Open);
       assert.strictEqual(protocol.getTests()[0].testRuns[1].isControl, true);
       assert.strictEqual(protocol.getTests()[0].testRuns[1].status, ManualTestStatus.Open);
-      assert.strictEqual(protocol.getTests()[3].testRuns[1].isControl, true);
-      assert.strictEqual(protocol.getTests()[3].testRuns[1].status, ManualTestStatus.Open);
-      mtp.parseComment(protocol, 6, retestAllComment);
+      assert.strictEqual(protocol.getTests()[3].testRuns[2].isControl, true);
+      assert.strictEqual(protocol.getTests()[3].testRuns[2].status, ManualTestStatus.Open);
+      mtp.parseComment(protocol, 7, retestAllComment);
       assert.strictEqual(protocol.getTests()[0].status(), ManualTestStatus.Open);
       assert.strictEqual(protocol.getTests()[1].status(), ManualTestStatus.Open);
       assert.strictEqual(protocol.getTests()[2].status(), ManualTestStatus.Open);
@@ -381,10 +398,10 @@ describe('ManualTestParser', function() {
       assert.strictEqual(protocol.getTests()[0].testRuns[2].status, ManualTestStatus.Open);
       assert.strictEqual(protocol.getTests()[1].testRuns[2].isControl, true);
       assert.strictEqual(protocol.getTests()[1].testRuns[2].status, ManualTestStatus.Open);
-      assert.strictEqual(protocol.getTests()[2].testRuns[1].isControl, true);
-      assert.strictEqual(protocol.getTests()[2].testRuns[1].status, ManualTestStatus.Open);
-      assert.strictEqual(protocol.getTests()[3].testRuns[2].isControl, true);
-      assert.strictEqual(protocol.getTests()[3].testRuns[2].status, ManualTestStatus.Open);
+      assert.strictEqual(protocol.getTests()[2].testRuns[2].isControl, true);
+      assert.strictEqual(protocol.getTests()[2].testRuns[2].status, ManualTestStatus.Open);
+      assert.strictEqual(protocol.getTests()[3].testRuns[3].isControl, true);
+      assert.strictEqual(protocol.getTests()[3].testRuns[3].status, ManualTestStatus.Open);
     });
 
     it('should retest', function() {
@@ -420,6 +437,9 @@ describe('ManualTestParser', function() {
       mtp.parseComment(protocol, 4, thirdTestRunComment);
       comment = mtp.getUserTestResultsComment(protocol);
       assert.strictEqual(comment, userTestResultsAllPassedComment);
+      mtp.parseComment(protocol, 5, skippedTestRunComment);
+      comment = mtp.getUserTestResultsComment(protocol);
+      assert.strictEqual(comment, userTestResultsSkippedComment);
     });
 
     it('should parse nested results', function() {

--- a/shared/manual-test/manual-test-parser.ts
+++ b/shared/manual-test/manual-test-parser.ts
@@ -140,7 +140,7 @@ export default class ManualTestParser {
   parseTestRunComment(protocol: ManualTestProtocol, id: number, comment: string): ManualTestProtocol {
     const lines = comment.replace(/\r/g, '').split('\n');
     const testTitleRegex = /^\s*(?:(?:[-*]|(?:#{1,4}))\s)?(?:\*\*)?(TEST|SUITE|GROUP)_([A-Z0-9_.-]+)(?:\*\*)?:?(?:\*\*)?\s*(.*?)\s*$/i;
-    const testStatusRegex = /(OPEN|PASSED|FAILED|BLOCKED|UNKNOWN|PASS|FAIL|BLOCK)(?:\*\*)? *(.*) *$/i;
+    const testStatusRegex = /(OPEN|PASSED|FAILED|BLOCKED|SKIPPED|UNKNOWN|PASS|FAIL|BLOCK|SKIP)(?:\*\*)? *(.*) *$/i;
 
     if(protocol.suites.length == 0) return;
     let suite: ManualTestSuite = protocol.suites[0];

--- a/shared/manual-test/manual-test-protocols.ts
+++ b/shared/manual-test/manual-test-protocols.ts
@@ -8,7 +8,8 @@ export enum ManualTestStatus {
   Open,     // Test has not yet been run
   Passed,   // Test has been run and passed
   Failed,   // Test has been run and failed
-  Blocked,  // Was not able to run test due to external issues
+  Blocked,  // Was not able to run test due to external issues, treated as failed
+  Skipped,  // Test was not run but should be treated as passed
   Unknown,  // ???
 };
 
@@ -22,12 +23,13 @@ export class ManualTestStatusUtil {
       case 'pass': return ManualTestStatus.Passed;
       case 'fail': return ManualTestStatus.Failed;
       case 'block': return ManualTestStatus.Blocked;
+      case 'skip': return ManualTestStatus.Skipped;
     }
     const result = ManualTestStatus[(status.substr(0,1).toUpperCase() + status.substr(1)) as keyof typeof ManualTestStatus];
     return result || ManualTestStatus.Open;
   }
   public static emoji(status: ManualTestStatus) {
-    const statusEmoji: string[] = ['⬜', '✅', '🟥', '🟧', '🟦'];
+    const statusEmoji: string[] = ['⬜', '✅', '🟥', '🟧', '🟩', '🟦'];
     return statusEmoji[status];
   }
 }
@@ -117,6 +119,7 @@ export class ManualTest {
 function reduceStatus(prev: ManualTestStatus, current: ManualTestStatus): ManualTestStatus {
   return prev == ManualTestStatus.Failed || current == ManualTestStatus.Failed ? ManualTestStatus.Failed :
     prev == ManualTestStatus.Blocked || current == ManualTestStatus.Blocked ? ManualTestStatus.Blocked :
+    prev == ManualTestStatus.Skipped || current == ManualTestStatus.Skipped ? ManualTestStatus.Skipped :
     prev == ManualTestStatus.Open || current == ManualTestStatus.Open ? ManualTestStatus.Open :
     current;
 }


### PR DESCRIPTION
Fixes #187.

'SKIPPED' test result type should be used when you want to treat a test as passing but the test was not actually completed successfully. For example, you may want to mark a test as 'SKIPPED' if it turns out to be irrelevant, or if a bug elsewhere stops the test from being completed, although in most cases you should probably use 'BLOCKED' if a test is never completed successfully, as this more clearly indicates that we have not actually verified that things work as we hope.