### PR TITLE
chore: use base ref for top comment

### DIFF
--- a/shared/manual-test/manual-test-protocols.ts
+++ b/shared/manual-test/manual-test-protocols.ts
@@ -36,7 +36,7 @@ export class ManualTestStatusUtil {
 
 export class ManualTestUtil {
   static commentLink(owner: string, repo: string, issuenum: number, commentId: number, isPR: boolean, baseIssueId?: number): string {
-    return `https://github.com/${owner}/${repo}/${isPR?'pull':'issues'}/${issuenum}#${commentId?'issuecomment':'issue'}-${commentId?commentId:baseIssueId}`
+    return `https://github.com/${owner}/${repo}/${isPR?'pull':'issues'}/${issuenum}#${commentId?('issuecomment-'+commentId):""}`
   }
 }
 


### PR DESCRIPTION
This works around what seems to be a GH bug in the id for the pr description anchor changing sporadically. Instead we ref the top of the document.

This is also why I kept trying to fix this and swapping back and forth -- because my test cases were unstable due to this GH issue. (I'm not going
to try and link the PRs in question, but you can find them if you search...)