### PR TITLE
feat(bot): Add Jenkins link to test comment

### DIFF
--- a/server/keymanapp-test-bot/artifact-links-comment.ts
+++ b/server/keymanapp-test-bot/artifact-links-comment.ts
@@ -39,7 +39,12 @@ export async function getArtifactLinksComment(
     if(s[context].state == 'success') {
       // artifactLinks
       const u = new URL(s[context].url);
-      if(u.searchParams.has('buildTypeId')) {
+      if (u.hostname == 'jenkins.lsdev.sil.org') {
+        for (let download of artifactLinks.jenkinsTarget.downloads) {
+          if (r == '') r = '\n## Test Artifacts\n\n';
+          r += `* [${download.name}](${s[context].url}/${download.fragment})\n`;
+        }
+      } else if(u.searchParams.has('buildTypeId')) {
         // Assume TeamCity
         let buildTypeId = u.searchParams.get('buildTypeId');
         let buildId = u.searchParams.get('buildId');

--- a/shared/artifact-links.ts
+++ b/shared/artifact-links.ts
@@ -31,7 +31,9 @@ export const artifactLinks = {
     ]},
   },
 
-  jenkinsTargets: {
-
+  jenkinsTarget: {
+    platform: 'linux', name: 'linux', icon: 'linux.png', downloads: [
+      { fragment: 'artifact/*zip*/archive.zip', name: 'Keyman for Linux', icon: 'keyman.png' }
+    ]
   }
 }


### PR DESCRIPTION
This theoretically would add the link to the Jenkins artifacts to the testing comment for a PR. I don't know if it actually works since I don't know how to test this :smile: 