### PR TITLE
feat: highlight PRs that close issues

### DIFF
--- a/public/src/app/issue-list/issue-list.component.css
+++ b/public/src/app/issue-list/issue-list.component.css
@@ -229,3 +229,8 @@ li {
   background: #60a060;
   border-radius: 6px;
 }
+
+.label a.will-close {
+  color: green;
+  font-weight: bold;
+}

--- a/public/src/app/issue-list/issue-list.component.html
+++ b/public/src/app/issue-list/issue-list.component.html
@@ -21,7 +21,7 @@
             <a class="author" title="{{issue.author.login}}" target="_blank" href="{issue.author.url}}"><img class="avatar-22" src="{{issue.author.avatarUrl}}&size=22"></a>
             <a class="issue" title="{{issue.title}}" target="_blank" href="{{issue.url}}">{{issueHasLinkedPR(issue) ? '✔ ': ''}}<b>{{issue.number}}</b> {{issue.title}}</a>
             <span class="related-pr" *ngFor="let pr of issue.timelineItems?.nodes">
-              <a href="{{pr.subject.url}}" target="_blank">{{pr.subject.url && pr.subject.url.includes('/pull/') ? '🔗' : '🔵'}}#{{pr.subject.number}}</a>
+              <a href="{{pr.subject.url}}" class="{{pr.willCloseTarget ? 'will-close' : ''}}" target="_blank">{{pr.subject.url && pr.subject.url.includes('/pull/') ? '🔗' : '🔵'}}#{{pr.subject.number}}</a>
             </span>
             <span *ngFor="let label of issue.labels?.nodes"><span class="issue-label" [style]="labelColor(label)">{{labelName(label.name)}}</span></span>
           </span>

--- a/public/src/app/issue-list/issue-list.component.ts
+++ b/public/src/app/issue-list/issue-list.component.ts
@@ -70,7 +70,7 @@ export class IssueListComponent extends PopupComponent implements OnInit {
 
   issueHasLinkedPR(issue) {
     return issue && issue.timelineItems && Array.isArray(issue.timelineItems.nodes) ?
-      issue.timelineItems.nodes.find(pr=>pr.subject.url&&pr.subject.url.includes('/pull/')) != null : false;
+      issue.timelineItems.nodes.find(pr => pr.subject.url && pr.subject.url.includes('/pull/') && pr.willCloseTarget) != null : false;
   }
 
   errorClassIfNonZero(v) {

--- a/server/services/github/github-issues.ts
+++ b/server/services/github/github-issues.ts
@@ -64,6 +64,7 @@ export default {
               nodes {
                 ... on CrossReferencedEvent {
                   __typename
+                  willCloseTarget
                   subject: source {
                     ... on PullRequest {
                       number


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4498365/161457285-94bc0561-1536-442a-9b70-7bcc7e70045b.png)

This minor tweak only adds the ✔ checkmark to an issue in the issue list if there is a corresponding PR that is marked to close it, and highlights that PR with bold green font. That is not always automatic with GitHub, so don't forget to do that linkage on your PRs/issues to get the benefit:

![image](https://user-images.githubusercontent.com/4498365/161457310-30f4f268-71a5-40d3-96dd-367bd4bf8087.png)