### PR TITLE
chore: Update Debian package name

### DIFF
--- a/public/src/app/deploy-box/deploy-box.component.ts
+++ b/public/src/app/deploy-box/deploy-box.component.ts
@@ -119,7 +119,7 @@ export class DeployBoxComponent extends PopupComponent implements OnInit, OnChan
             version: this.status?.deployment?.[StatusSource.LinuxLsdevSilOrgStable]?.version
           }, {
             name: 'Debian Unstable',
-            url: `https://tracker.debian.org/pkg/keyman-config`,
+            url: `https://tracker.debian.org/pkg/keyman`,
             version: this.status?.deployment?.[StatusSource.DebianStable]?.version,
           });
         } else if (this.tier == 'beta' || this.tier == 'alpha') {

--- a/server/services/deployment/debian.ts
+++ b/server/services/deployment/debian.ts
@@ -5,7 +5,7 @@
 import httpget from "../../util/httpget";
 import DataService from "../data-service";
 
-// https://sources.debian.org/api/src/keyman-config/
+// https://sources.debian.org/api/src/keyman/
 const HOST = 'sources.debian.org';
 const PATH_PREFIX = '/api/src/';
 
@@ -17,8 +17,7 @@ const service = {
 				return null;
 			default:
 				{
-					//TODO: after 'keyman' is accepted, update compnent to use 'keyman' for alpha and beta, and eventually stable tiers
-					const component: string = tier == 'stable' ? 'keyman-config/' : 'keyman-config/';
+					const component = 'keyman/';
 					return httpget(HOST, PATH_PREFIX + component).then((data) => {
 						const results = JSON.parse(data.data);
 						if (results && typeof results.versions == 'object' && results.versions.length > 0) {


### PR DESCRIPTION
The Keyman 15 packages have been accepted, so we need to adjust the package name. This also means that the `keyman-config` source package is no longer available.