### PR TITLE
chore: handle null and invalid urls

### DIFF
--- a/public/src/app/pull-request/pull-request.component.ts
+++ b/public/src/app/pull-request/pull-request.component.ts
@@ -129,7 +129,13 @@ export class PullRequestComponent extends PopupComponent implements OnInit, OnCh
   };
 
   getDownloads(context) {
-    let url = new URL(context.targetUrl);
+    let url;
+    try {
+      url = new URL(context.targetUrl);
+    } catch(e) {
+      console.trace(e);
+      return {};
+    }
     let result = {platform: '', downloads: [], name: '', icon: ''};
     if(url.hostname == 'build.palaso.org') {
       let buildId = url.searchParams.get('buildId');

--- a/public/src/app/pull-request/pull-request.component.ts
+++ b/public/src/app/pull-request/pull-request.component.ts
@@ -129,14 +129,22 @@ export class PullRequestComponent extends PopupComponent implements OnInit, OnCh
   };
 
   getDownloads(context) {
+    let result = {platform: '', downloads: [], name: '', icon: ''};
+
+    if(!context.targetUrl) {
+      return result;
+    }
+
     let url;
     try {
       url = new URL(context.targetUrl);
     } catch(e) {
+      console.log('getDownloads failed.');
+      console.debug(context);
       console.trace(e);
-      return {};
+      return result;
     }
-    let result = {platform: '', downloads: [], name: '', icon: ''};
+
     if(url.hostname == 'build.palaso.org') {
       let buildId = url.searchParams.get('buildId');
       let buildTypeId = url.searchParams.get('buildTypeId');


### PR DESCRIPTION
When we have the file-size check, that has a null targetUrl, which broke the status data.