### PR TITLE
fix: test bot was failing with missing data

### DIFF
--- a/server/keymanapp-test-bot/artifact-links-comment.ts
+++ b/server/keymanapp-test-bot/artifact-links-comment.ts
@@ -81,7 +81,7 @@ export async function getArtifactLinksComment(
           }
           if(t.platform == 'ios') {
             // Special case note for TestFlight
-            let buildCounter = buildData.resultingProperties.property.find(prop => prop.name == 'build.counter')?.value;
+            let buildCounter = buildData?.resultingProperties?.property?.find(prop => prop.name == 'build.counter')?.value;
             if(buildCounter) {
               links[t.name].push({
                 platform: t.name,


### PR DESCRIPTION
Fixes following error, which arises when a build has gone stale.

```
2022-05-21T08:37:25.548740074Z: [ERROR]  This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason:
2022-05-21T08:37:25.549713879Z: [ERROR]  TypeError: Cannot read properties of undefined (reading 'resultingProperties')
2022-05-21T08:37:25.549749479Z: [ERROR]      at Object.<anonymous> (/home/site/wwwroot/server/keymanapp-test-bot/artifact-links-comment.ts:84:42)
2022-05-21T08:37:25.549756079Z: [ERROR]      at Generator.next (<anonymous>)
2022-05-21T08:37:25.549760479Z: [ERROR]      at fulfilled (/home/site/wwwroot/server/dist/server/keymanapp-test-bot/artifact-links-comment.js:5:58)
```