### PR TITLE
fix: support inferred 'all' for test bot retest control

### DIFF
--- a/server/test/manual-test-parser.spec.ts
+++ b/server/test/manual-test-parser.spec.ts
@@ -442,6 +442,44 @@ describe('ManualTestParser', function() {
       assert.strictEqual(protocol.getTests()[2].status(), ManualTestStatus.Open);
       assert.strictEqual(protocol.getTests()[3].status(), ManualTestStatus.Open);
     });
+
+    it('should retest a group with an inferred "all" control', function() {
+      // setup
+      let mtp = new ManualTestParser();
+      let protocol = new ManualTestProtocol('keymanapp', 'keyman', 1, false, 0);
+      mtp.parseComment(protocol, 1, `
+# User Testing
+
+GROUP_COLOUR
+GROUP_MONO
+TEST_SPELLING: test spelling
+TEST_GRAMMAR: test grammar
+`, userLogin);
+      mtp.parseComment(protocol, 2, `
+### GROUP_COLOUR:
+
+* **TEST_SPELLING (PASS):**
+* **TEST_GRAMMAR (PASS):**
+
+### GROUP_MONO:
+
+* **TEST_SPELLING (PASS):**
+* **TEST_GRAMMAR (PASS):**
+`, userLogin);
+      assert.strictEqual(protocol.getTests()[0].status(), ManualTestStatus.Passed);
+      assert.strictEqual(protocol.getTests()[1].status(), ManualTestStatus.Passed);
+      assert.strictEqual(protocol.getTests()[2].status(), ManualTestStatus.Passed);
+      assert.strictEqual(protocol.getTests()[3].status(), ManualTestStatus.Passed);
+
+      // test
+      assert.strictEqual(mtp.isControlComment(`@keymanapp-test-bot retest GROUP_MONO`, userLogin), true);
+      mtp.parseComment(protocol, 3, `@keymanapp-test-bot retest GROUP_MONO`, userLogin);
+      assert.strictEqual(protocol.getTests()[0].status(), ManualTestStatus.Passed);
+      assert.strictEqual(protocol.getTests()[1].status(), ManualTestStatus.Passed);
+      assert.strictEqual(protocol.getTests()[2].status(), ManualTestStatus.Open);
+      assert.strictEqual(protocol.getTests()[3].status(), ManualTestStatus.Open);
+    });
+
   });
 
   describe('getUserTestResultsComment()', function() {

--- a/shared/manual-test/manual-test-parser.ts
+++ b/shared/manual-test/manual-test-parser.ts
@@ -254,8 +254,9 @@ export default class ManualTestParser {
 
     let suite: ManualTestSuite = null;
     let group: ManualTestGroup = null;
-
+    let isCollection = false;
     for(let match of matches) {
+      isCollection = !!match.match(/^(SUITE|GROUP)_/i);
       if(match.match(/^SUITE_/i)) {
         suite = protocol.findSuite(match.substring(6));
       } else if(match.match(/^GROUP_/i)) {
@@ -270,6 +271,14 @@ export default class ManualTestParser {
         }
       }
     }
+
+    if(isCollection) {
+      // We've got an inferred 'all' on the end of the test spec
+      for(let test of (group || suite).getTests()) {
+        test.addRun(id, true, ManualTestStatus.Open);
+      }
+    }
+
     return protocol;
   }
 


### PR DESCRIPTION
Fixes #292.