### PR TITLE
fix: show fixed,open issues when view=all

### DIFF
--- a/public/src/app/count-box/count-box.component.html
+++ b/public/src/app/count-box/count-box.component.html
@@ -1,5 +1,5 @@
 <a target='_blank' href='{{repo == "*" ?
-  "https://github.com/keymanapp/" : "https://github.com/keymanapp/"+repo+"/"+modeUri()+"?utf8=%E2%9C%93&q=is%3Aopen+"+modeFilter()+filter()}}' *ngIf="unfixedCount > 0">
+  "https://github.com/keymanapp/" : "https://github.com/keymanapp/"+repo+"/"+modeUri()+"?utf8=%E2%9C%93&q=is%3Aopen+"+modeFilter()+filter()}}' *ngIf="unfixedCount > 0 || (count > 0 && alwaysShow)">
   <span class='countbox {{class}}'>
     <span class='countbox-title'>{{title}}</span>
     <span class='countbox-value'>{{unfixedCount}} <span class='countbox-total' *ngIf="unfixedCount < count">({{count}})</span></span>

--- a/public/src/app/count-box/count-box.component.ts
+++ b/public/src/app/count-box/count-box.component.ts
@@ -13,6 +13,7 @@ export class CountBoxComponent implements OnInit {
   @Input() class?: string;
   @Input() label?: string;
   @Input() isPulls: boolean;
+  @Input() alwaysShow: boolean;
 
   filter() {
     let f = "";

--- a/public/src/app/issue-list/issue-list.component.html
+++ b/public/src/app/issue-list/issue-list.component.html
@@ -6,6 +6,7 @@
     [unfixedCount]="getUnfixedIssueCount()"
     [count]="milestone?.count"
     [label]="platform?.value.id ? platform?.value.id+'/' : null"
+    [alwaysShow]="view == 'all'"
     [class]="repo == '*' || repo == 'keyboards' || repo == 'lexical-models' ? 'milestone-all' : 'milestone-'+milestone?.id"></app-count-box>
 
   <span *ngIf="isNav" class="navbar-new-issues">


### PR DESCRIPTION
If you fixed the last issue for a milestone for a given platform, the issue counter would disappear entirely. This fix makes it so that the issue counter will be visible for the 'all' view, but not for the 'current' view, so that we reduce the noise to active work items for the 'current' view.