### PR TITLE
chore: Add Android KeyboardHarness links

### DIFF
--- a/public/src/app/pull-request/pull-request.component.ts
+++ b/public/src/app/pull-request/pull-request.component.ts
@@ -116,6 +116,7 @@ export class PullRequestComponent extends PopupComponent implements OnInit, OnCh
     'KeymanAndroid_TestSamplesAndTestProjects': {platform: 'android', name: 'Android', icon: 'android.png', downloads: [
       {fragment: 'Samples/KMSample1/app-debug.apk', name: 'KMSample1 apk', icon: 'kmsample1.png'} ,
       {fragment: 'Samples/KMSample2/app-debug.apk', name: 'KMSample2 apk', icon: 'kmsample2.png'} ,
+      {fragment: 'Tests/KeyboardHarness/app-debug.apk', name: 'KeyboardHarness apk', icon: 'keyboardharness.png'} ,
     ]},
 
     'Keyman_iOS_TestPullRequests': {platform: 'ios', name: 'iOS', icon: 'ios.png', downloads: [

--- a/shared/artifact-links.ts
+++ b/shared/artifact-links.ts
@@ -9,6 +9,7 @@ export const artifactLinks = {
     'KeymanAndroid_TestSamplesAndTestProjects': {platform: 'android', name: 'Android', icon: 'android.png', downloads: [
       {fragment: 'Samples/KMSample1/app-debug.apk', name: 'KMSample1 apk', icon: 'kmsample1.png'} ,
       {fragment: 'Samples/KMSample2/app-debug.apk', name: 'KMSample2 apk', icon: 'kmsample2.png'} ,
+      {fragment: 'Tests/KeyboardHarness/app-debug.apk', name: 'KeyboardHarness apk', icon: 'keyboardharness.png'} ,
     ]},
 
     'Keyman_iOS_TestPullRequests': {platform: 'ios', name: 'iOS', icon: 'ios.png', downloads: [


### PR DESCRIPTION
@jahorton was looking to update some user tests involving chiral keyboard.
On the CI, **Keyman - Android/ Test: Samples and Test projects** is already creating artifacts for KeyboardHarness, so this adds links for the test-bot
