### PR TITLE
fix: use 'common' label for issues without scope

### DIFF
--- a/server/keymanapp-test-bot/emoji-label.ts
+++ b/server/keymanapp-test-bot/emoji-label.ts
@@ -156,8 +156,8 @@ async function applyIssueLabels(
     .map(label => typeof label == 'string' ? label : label.name);
 
   const labelsToAdd =
-    // add any scopes
-    (matches[2] ?? '')
+    // add any scopes -- if no scope defined, the issue goes under 'common'
+    (matches[2] || 'common')
     .split(',')
     .map(name => name.trim().toLowerCase() + '/')
     .filter(name => validScopeLabels.includes(name))


### PR DESCRIPTION
If you create an issue that is valid CC format but has no scope, it will
be given 'common' scope by the bot.