### PR TITLE
chore: poll community site

### DIFF
--- a/server/code.ts
+++ b/server/code.ts
@@ -250,6 +250,7 @@ function respondPolledEndpoints() {
   for(let s of STATUS_SOURCES) {
     statusData.refreshEndpointData(s).then(hasChanged => sendWsAlert(hasChanged, s));
   }
+  doDiscourseDataChange();
 }
 
 function sendInitialRefreshMessages(socket) {


### PR DESCRIPTION
As discourse doesn't notify on changes to tags, we now poll the
community site once a minute so that we get updated tags on the list of
topics.