### PR TITLE
fix: recursive ref if fork has PR from master

### DIFF
--- a/public/src/app/home/home.component.ts
+++ b/public/src/app/home/home.component.ts
@@ -720,7 +720,7 @@ export class HomeComponent {
     pulls.forEach(pull => { refs[pull.pull.node.headRefName] = new TreeNode(pull); });
     pulls.forEach(pull => {
       const node = refs[pull.pull.node.headRefName];
-      node.parent = refs[pull.pull.node.baseRefName] || root;
+      node.parent = (refs[pull.pull.node.baseRefName] == node ? root : refs[pull.pull.node.baseRefName]) || root;
       node.parent.children.push(node);
     });
 


### PR DESCRIPTION
If a PR comes from a fork:master, then we ended up with a recursive
reference in our tree analysis of the PR chains, which meant that
various views would not see all the open PRs.