### PR TITLE
chore: manage rate limits for GitHub

### DIFF
--- a/server/data/status-data.ts
+++ b/server/data/status-data.ts
@@ -166,7 +166,7 @@ export class StatusData {
       contributions = await logAsync('refreshGitHubContributionsData', () => githubContributionsService.get(sprintStartDateTime));
 
       for(let node of contributions?.data?.repository?.contributions?.nodes) {
-        node.contributions.tests = {nodes: await logAsync('refreshGitHubContributionsData[n]', () => githubTestContributionsService.get(null, [], sprintStartDateTime, node.login))};
+        node.contributions.tests = {nodes: await logAsync(`refreshGitHubContributionsTestsData(${node.login})`, () => githubTestContributionsService.get(null, [], sprintStartDateTime, node.login))};
       }
     } catch(e) {
       console.log(e);

--- a/server/services/github/github-contributions.ts
+++ b/server/services/github/github-contributions.ts
@@ -1,6 +1,7 @@
 
 import httppost from '../../util/httppost';
 import { github_token } from '../../identity/github';
+import { logGitHubRateLimit } from '../../util/github-rate-limit';
 
 export default {
 
@@ -13,7 +14,11 @@ export default {
       // Gather the contributions for each recent user
 
       JSON.stringify({query: this.queryString(startDateTime)}),
-    ).then(data => JSON.parse(data));
+    ).then(data => {
+      const result = JSON.parse(data);
+      logGitHubRateLimit(result?.data?.rateLimit, 'github-contributions');
+      return result;
+    });
   },
 
   queryString: function(startDate) {
@@ -22,6 +27,13 @@ export default {
     let endDate = d.toISOString();
     return `
     {
+      rateLimit {
+        limit
+        cost
+        remaining
+        resetAt
+      }
+
       repository(owner: "keymanapp", name: "keyman") {
 
         # Collect contributions

--- a/server/services/github/github-issues.ts
+++ b/server/services/github/github-issues.ts
@@ -1,6 +1,7 @@
 
 import httppost from '../../util/httppost';
 import { github_token } from '../../identity/github';
+import { logGitHubRateLimit } from '../../util/github-rate-limit';
 // import { getCurrentSprint } from '../../current-sprint';
 
 export default {
@@ -17,6 +18,8 @@ export default {
       JSON.stringify({query: ghIssuesQuery})
     ).then(data => {
       let obj = JSON.parse(data);
+
+      logGitHubRateLimit(obj?.data?.rateLimit, 'github-issues');
       //console.log(data);
       if(!obj.data || !obj.data.search) return [];
       const newIssues = [].concat(issues, obj.data.search.nodes);
@@ -113,7 +116,10 @@ export default {
       }
 
       rateLimit {
+        limit
         cost
+        remaining
+        resetAt
       }
     }
     `

--- a/server/services/github/github-test-contributions.ts
+++ b/server/services/github/github-test-contributions.ts
@@ -1,6 +1,7 @@
 
 import httppost from '../../util/httppost';
 import { github_token } from '../../identity/github';
+import { logGitHubRateLimit } from '../../util/github-rate-limit';
 
 export default {
 
@@ -17,6 +18,8 @@ export default {
     ).then(data => {
       let obj = JSON.parse(data);
       if(!obj.data || !obj.data.user) return [];
+
+      logGitHubRateLimit(obj?.data?.rateLimit, 'github-test-contributions');
 
       let targetDate = new Date(startDate);
       let results = obj.data.user.issueComments.nodes.filter(result => new Date(result.createdAt) >= targetDate);
@@ -50,6 +53,13 @@ export default {
     after = JSON.stringify(after);
     return `
     {
+      rateLimit {
+        limit
+        cost
+        remaining
+        resetAt
+      }
+
       user(login: "${user}") {
 
         # Collect test result contributions

--- a/server/util/github-rate-limit.ts
+++ b/server/util/github-rate-limit.ts
@@ -1,0 +1,3 @@
+export function logGitHubRateLimit(rateLimit, module) {
+  console.log(`[RATE LIMIT] ${module}: cost=${rateLimit?.cost} remaining=${rateLimit?.remaining}`);
+}


### PR DESCRIPTION
Fixes #420.

Adds server-side logging for rate limiting and cost for each GraphQL query. Note that this misses rate limit data for the REST API usage (currently only github-milestones.ts, which should have a cost of 1).

Tweaks the expensive github-status:organization query to reduce the cost from 100 to 48, by retrieving fewer PRs per repo (max of 20), and max of 60 repos. This means that if we start getting many PRs on a single repo, we may not have visibility.

This is an interim fix, would be much better to use cached data and fold changes in that are given to us by the GH webhook notifications, but that's a much, much more complex change.