### PR TITLE
fix: community site - handle errors

### DIFF
--- a/server/services/discourse/discourse.ts
+++ b/server/services/discourse/discourse.ts
@@ -8,7 +8,11 @@ export default {
       contributions: {}
     };
     for(let user of Object.keys(userIds)) {
-      result.contributions[user] = await this.getUser(startDate, userIds[user].community);
+      try {
+        result.contributions[user] = await this.getUser(startDate, userIds[user].community);
+      } catch(e) {
+        console.log(`Error retrieving discourse contributions for ${user}: ${e}`);
+      }
     }
 
     return result;


### PR DESCRIPTION
Was getting an error which was handled too far up the stack:

    statusCode for community.software.sil.org/user_actions.json?offset=0&username=Nguonnyny_Tan&limit=60&filter=4,5: 404

Fixes #435.