### PR TITLE
fix: new teamcity status url format

### DIFF
--- a/public/src/app/pull-request/pull-request.component.ts
+++ b/public/src/app/pull-request/pull-request.component.ts
@@ -7,6 +7,7 @@ import { PopupCoordinatorService } from '../popup-coordinator.service';
 import { pullStatus, pullUserTesting, pullBuildState, pullBuildStateEx } from '../utility/pullStatus';
 import { VisibilityService } from '../visibility/visibility.service';
 import { getAuthorAvatarUrl } from '../../../../shared/users';
+import { getTeamcityUrlParams } from '../../../../shared/getTeamcityUrlParams';
 import { pullEmoji } from '../utility/pullEmoji';
 
 @Component({
@@ -213,8 +214,7 @@ export class PullRequestComponent extends PopupComponent implements OnInit, OnCh
     }
 
     if(url.hostname == 'build.palaso.org') {
-      let buildId = url.searchParams.get('buildId');
-      let buildTypeId = url.searchParams.get('buildTypeId');
+      const { buildId, buildTypeId } = getTeamcityUrlParams(url);
       let targets = this.teamCityTargets[buildTypeId];
       if(targets) {
         result.name = targets.name;

--- a/shared/getTeamcityUrlParams.ts
+++ b/shared/getTeamcityUrlParams.ts
@@ -1,0 +1,14 @@
+export function getTeamcityUrlParams(u: URL) {
+  let buildTypeId: string = null, buildId: string = null;
+  // Assume TeamCity
+  const re = /\/buildConfiguration\/([^\/]+)\/(\d+)$/.exec(u.pathname);
+  if (re) {
+    // 2024 update of teamCity
+    buildTypeId = re[1];
+    buildId = re[2];
+  } else {
+    buildTypeId = u.searchParams.get('buildTypeId');
+    buildId = u.searchParams.get('buildId');
+  }
+  return { buildTypeId, buildId };
+}


### PR DESCRIPTION
TeamCity appears to be using a new format for its status urls as of a few days ago (version 2024.03?). Updates testbot and status page to parse these new urls (while maintaining support for old pattern for now as well).