### PR TITLE
change: tweak issue label list to match current practice

### DIFF
--- a/server/keymanapp-test-bot/emoji-label.ts
+++ b/server/keymanapp-test-bot/emoji-label.ts
@@ -140,7 +140,7 @@ export async function processEpicLabelsEmoji(
 // Attempt to automatically add labels corresponding to issue title
 //
 // type(scope[,scope...]): title [emoji]
-// type: auto|bug|chore|docs|feat|refactor|spec|test
+// type: auto|bug|change|chore|docs|feat|refactor|spec|style|test
 // scope: android|common|core|developer|ios|linux|mac|web|windows
 //
 async function applyIssueLabels(

--- a/shared/issue-labels.ts
+++ b/shared/issue-labels.ts
@@ -5,7 +5,7 @@ export const issueLabelScopes = [
 ];
 
 export const issueLabelTypes = [
-  'auto', 'bug', 'bug', 'chore', 'docs', 'feat', 'refactor', 'spec', 'test'
+  'auto', 'bug', 'change', 'chore', 'docs', 'feat', 'refactor', 'spec', 'style', 'test'
 ];
 
-export const issueValidTitleRegex = /^(auto|bug|chore|docs|feat|refactor|spec|test)(?:\(([a-z, ]+)\))?:/;
+export const issueValidTitleRegex = /^(auto|bug|change|chore|docs|feat|refactor|spec|style|test)(?:\(([a-z, ]+)\))?:/;


### PR DESCRIPTION
Adds 'change', 'style'. This only affects issues; PR labels are managed in keymanapp/keyman repo.