### PR TITLE
chore: get git issues going again

### DIFF
--- a/server/services/github/github-status.ts
+++ b/server/services/github/github-status.ts
@@ -89,7 +89,7 @@ const queryStrings = {
       issuesWithNoMilestone: issues(first: 1, filterBy: {milestone: null, states: OPEN}) {
         totalCount
       }
-      issuesByLabelAndMilestone: labels(first: 100, query: "${issueLabelScopes.join(' ')}") {
+      issuesByLabelAndMilestone: labels(first: 100) {
         edges {
           node {
             name


### PR DESCRIPTION
It seems like something changed in the GH backend because all of a sudden our query for labels returned only 'core/', instead of returning labels for all the platforms. So have removed the filter, which means more data coming in...