### PR TITLE
fix:  use last review date for pr status calculation when comparing against last review request

### DIFF
--- a/public/src/app/utility/pullStatus.ts
+++ b/public/src/app/utility/pullStatus.ts
@@ -26,7 +26,8 @@ export function pullStatus(pull) {
 
   if(pr.reviewsRequested?.nodes?.length) {
     const latestReviewRequest = pr.reviewsRequested.nodes[pr.reviewsRequested.nodes.length - 1];
-    if(new Date(latestReviewRequest.createdAt) >= latestReviewStatus[1]) {
+    if(pr.reviews.nodes.length == 0 ||
+        new Date(latestReviewRequest.createdAt) >= new Date(pr.reviews.nodes[pr.reviews.nodes.length-1].updatedAt)) {
       return 'status-pending';
     }
   }


### PR DESCRIPTION
e.g. for keymanapp/keyman#11637, was matching against the wrong author's review previously, which was not the last review 