### PR TITLE
chore: update links for Linux

### DIFF
--- a/public/src/app/deploy-box/deploy-box.component.ts
+++ b/public/src/app/deploy-box/deploy-box.component.ts
@@ -111,11 +111,11 @@ export class DeployBoxComponent extends PopupComponent implements OnInit, OnChan
             date: this.status?.deployment?.[StatusSource.LaunchPadStable]?.date_published.substr(0, 10)
           }, {
             name: 'packages.sil.org',
-            url: 'https://packages.sil.org/ubuntu/?prefix=ubuntu/pool/main/k/keyman-config/',
+            url: 'https://packages.sil.org/ubuntu/?prefix=ubuntu/pool/main/k/keyman/',
             version: this.status?.deployment?.[StatusSource.PackagesSilOrg]?.version
           }, {
             name: 'linux.lsdev.sil.org',
-            url: '',  // Disabled, see #250 url: 'http://linux.lsdev.sil.org/ubuntu/pool/main/k/keyman-config/',
+            url: '',  // Disabled, see #250 url: 'http://linux.lsdev.sil.org/ubuntu/pool/main/k/keyman/',
             version: this.status?.deployment?.[StatusSource.LinuxLsdevSilOrgStable]?.version
           }, {
             name: 'Debian Unstable',

--- a/server/services/deployment/launch-pad.ts
+++ b/server/services/deployment/launch-pad.ts
@@ -5,12 +5,12 @@
 import httpget from "../../util/httpget";
 import DataService from "../data-service";
 
-// https://api.launchpad.net/1.0/~keymanapp/+archive/ubuntu/keyman-alpha?ws.op=getPublishedBinaries&ws.size=1&order_by_date=true&binary_name=keyman-config
-// https://api.launchpad.net/1.0/~keymanapp/+archive/ubuntu/keyman-beta?ws.op=getPublishedBinaries&ws.size=1&order_by_date=true&binary_name=keyman-config
-// https://api.launchpad.net/1.0/~keymanapp/+archive/ubuntu/keyman?ws.op=getPublishedBinaries&ws.size=1&order_by_date=true&binary_name=keyman-config
+// https://api.launchpad.net/1.0/~keymanapp/+archive/ubuntu/keyman-alpha?ws.op=getPublishedBinaries&ws.size=1&order_by_date=true&binary_name=keyman
+// https://api.launchpad.net/1.0/~keymanapp/+archive/ubuntu/keyman-beta?ws.op=getPublishedBinaries&ws.size=1&order_by_date=true&binary_name=keyman
+// https://api.launchpad.net/1.0/~keymanapp/+archive/ubuntu/keyman?ws.op=getPublishedBinaries&ws.size=1&order_by_date=true&binary_name=keyman
 const HOST='api.launchpad.net';
 const PATH_PREFIX='/1.0/~keymanapp/+archive/ubuntu/keyman';
-const PATH_SUFFIX='?ws.op=getPublishedBinaries&ws.size=1&order_by_date=true&binary_name=keyman-config';
+const PATH_SUFFIX='?ws.op=getPublishedBinaries&ws.size=1&order_by_date=true&binary_name=keyman';
 
 const service = {
    get: function(tier) {

--- a/server/services/deployment/linux-lsdev-sil-org.ts
+++ b/server/services/deployment/linux-lsdev-sil-org.ts
@@ -29,9 +29,9 @@ Version: 15.0.100-1+focal1
 import httpget from "../../util/httpget";
 import DataService from "../data-service";
 
-// http://linux.lsdev.sil.org/ubuntu/dists/focal<llsoTier>/main/binary-amd64/Packages
+// http://linux.lsdev.sil.org/ubuntu/dists/noble<llsoTier>/main/binary-amd64/Packages
 const HOST ='linux.lsdev.sil.org';
-const PATH_PREFIX='/ubuntu/dists/focal';
+const PATH_PREFIX='/ubuntu/dists/noble';
 const PATH_SUFFIX='/main/binary-amd64/Packages';
 
 const service = {

--- a/server/services/deployment/packages-sil-org.ts
+++ b/server/services/deployment/packages-sil-org.ts
@@ -12,8 +12,7 @@ or:
 
 ```
 Package: keyman
-Source: keyman-config
-Version: 14.0.273-1+focal1
+Version: 17.0.330-1+noble1
 ```
 
 */
@@ -21,14 +20,14 @@ Version: 14.0.273-1+focal1
 import httpget from "../../util/httpget";
 import DataService from "../data-service";
 
-// https://packages.sil.org/ubuntu/dists/focal/main/binary-amd64/Packages
+// https://packages.sil.org/ubuntu/dists/noble/main/binary-amd64/Packages
 const HOST='packages.sil.org';
-const PATH='/ubuntu/dists/focal/main/binary-amd64/Packages';
+const PATH='/ubuntu/dists/noble/main/binary-amd64/Packages';
 
 const service: DataService = {
    get: function() {
     return httpget(HOST, PATH).then((data) => {
-      const results = data.data.match(/^Package: keyman\s*\nSource:\s*keyman[^\n]*\nVersion: (\d+\.\d+\.\d+)-\d+/m);
+      const results = data.data.match(/^Package: keyman\s*\n(Source:\s*keyman[^\n]*\n)?Version: (\d+\.\d+\.\d+)-\d+/m);
       if(results) {
         return { version: results[1] };
       }

--- a/server/services/deployment/packages-sil-org.ts
+++ b/server/services/deployment/packages-sil-org.ts
@@ -29,7 +29,7 @@ const service: DataService = {
     return httpget(HOST, PATH).then((data) => {
       const results = data.data.match(/^Package: keyman\s*\n(Source:\s*keyman[^\n]*\n)?Version: (\d+\.\d+\.\d+)-\d+/m);
       if(results) {
-        return { version: results[1] };
+        return { version: results[2] };
       }
 
       return null;


### PR DESCRIPTION
- link to `keyman` instead of `keyman-config`
- fix version detection on pso
- use packages for `noble` instead of `focal` to determine version