### PR TITLE
fix: get correct version from Launchpad

### DIFF
--- a/server/services/deployment/launch-pad.ts
+++ b/server/services/deployment/launch-pad.ts
@@ -5,12 +5,12 @@
 import httpget from "../../util/httpget";
 import DataService from "../data-service";
 
-// https://api.launchpad.net/1.0/~keymanapp/+archive/ubuntu/keyman-alpha?ws.op=getPublishedBinaries&ws.size=1&order_by_date=true&binary_name=keyman
-// https://api.launchpad.net/1.0/~keymanapp/+archive/ubuntu/keyman-beta?ws.op=getPublishedBinaries&ws.size=1&order_by_date=true&binary_name=keyman
-// https://api.launchpad.net/1.0/~keymanapp/+archive/ubuntu/keyman?ws.op=getPublishedBinaries&ws.size=1&order_by_date=true&binary_name=keyman
+// https://api.launchpad.net/1.0/~keymanapp/+archive/ubuntu/keyman-alpha?ws.op=getPublishedBinaries&ws.size=1&order_by_date=true&exact_match=true&binary_name=keyman
+// https://api.launchpad.net/1.0/~keymanapp/+archive/ubuntu/keyman-beta?ws.op=getPublishedBinaries&ws.size=1&order_by_date=true&exact_match=true&binary_name=keyman
+// https://api.launchpad.net/1.0/~keymanapp/+archive/ubuntu/keyman?ws.op=getPublishedBinaries&ws.size=1&order_by_date=true&exact_match=true&binary_name=keyman
 const HOST='api.launchpad.net';
 const PATH_PREFIX='/1.0/~keymanapp/+archive/ubuntu/keyman';
-const PATH_SUFFIX='?ws.op=getPublishedBinaries&ws.size=1&order_by_date=true&binary_name=keyman';
+const PATH_SUFFIX='?ws.op=getPublishedBinaries&ws.size=1&order_by_date=true&exact_match=true&binary_name=keyman';
 
 const service = {
    get: function(tier) {


### PR DESCRIPTION
This fixes the problem where we showed the version number from onboard because that was the latest package uploaded to launchpad. We now exactly match the name of the binary package which will report the correct version number for Keyman.