### PR TITLE
chore: move from @keymanapp/models-types to @keymanapp/common-types

### DIFF
--- a/public/src/app/data/data.model.ts
+++ b/public/src/app/data/data.model.ts
@@ -123,7 +123,7 @@ export class DataModel {
       case StatusSource.LinuxLsdevSilOrgBeta:
       case StatusSource.LinuxLsdevSilOrgStable:
       case StatusSource.NpmKeymanCompiler:
-      case StatusSource.NpmModelsTypes:
+      case StatusSource.NpmCommonTypes:
         this.status.deployment[source] = data.data;
         this.changeCounter++; // forces a rebuild
         break;

--- a/public/src/app/deploy-box/deploy-box.component.ts
+++ b/public/src/app/deploy-box/deploy-box.component.ts
@@ -159,9 +159,9 @@ export class DeployBoxComponent extends PopupComponent implements OnInit, OnChan
           url: 'https://npmjs.com/package/@keymanapp/kmc',
           version: this.status?.deployment?.[StatusSource.NpmKeymanCompiler]?.[this.tier]?.split('-')[0]
         }, {
-          name: '@keymanapp/models-types',
-          url: 'https://npmjs.com/package/@keymanapp/models-types',
-          version: this.status?.deployment?.[StatusSource.NpmModelsTypes]?.[this.tier]?.split('-')[0]
+          name: '@keymanapp/common-types',
+          url: 'https://npmjs.com/package/@keymanapp/common-types',
+          version: this.status?.deployment?.[StatusSource.NpmCommonTypes]?.[this.tier]?.split('-')[0]
         });
         break;
     }

--- a/server/code.ts
+++ b/server/code.ts
@@ -127,7 +127,7 @@ const STATUS_SOURCES: StatusSource[] = [
   StatusSource.DebianBeta,
   StatusSource.DebianStable,
   StatusSource.NpmKeymanCompiler,
-  StatusSource.NpmModelsTypes,
+  StatusSource.NpmCommonTypes,
   StatusSource.SKeymanCom,
   StatusSource.PackagesSilOrg,
   StatusSource.LinuxLsdevSilOrgAlpha,

--- a/server/data/status-data.ts
+++ b/server/data/status-data.ts
@@ -15,7 +15,7 @@ import { launchPadAlphaService, launchPadBetaService, launchPadStableService } f
 import packagesSilOrgService from "../services/deployment/packages-sil-org";
 import { linuxLsdevSilOrgAlphaService, linuxLsdevSilOrgBetaService, linuxLsdevSilOrgStableService } from "../services/deployment/linux-lsdev-sil-org";
 import { debianBetaService, debianStableService } from "../services/deployment/debian";
-import { kmcService, mtService } from "../services/deployment/npmjs";
+import { kmcService, ctService } from "../services/deployment/npmjs";
 import { StatusSource } from "../../shared/status-source";
 import discourseService from "../services/discourse/discourse";
 import { performanceLog } from "../performance-log";
@@ -37,7 +37,7 @@ services[StatusSource.LinuxLsdevSilOrgStable] = linuxLsdevSilOrgStableService;
 services[StatusSource.DebianBeta] = debianBetaService;
 services[StatusSource.DebianStable] = debianStableService;
 services[StatusSource.NpmKeymanCompiler] = kmcService;
-services[StatusSource.NpmModelsTypes] = mtService;
+services[StatusSource.NpmCommonTypes] = ctService;
 services[StatusSource.CommunitySite] = discourseService;
 
 export interface StatusDataCache {

--- a/server/services/deployment/npmjs.ts
+++ b/server/services/deployment/npmjs.ts
@@ -40,7 +40,7 @@ const service = {
 };
 
 const KMC_PATH='/@keymanapp/kmc';
-const MT_PATH='/@keymanapp/models-types';
+const CT_PATH='/@keymanapp/common-types';
 
 class ServiceClass implements DataService {
   private etag = '';
@@ -60,4 +60,4 @@ class ServiceClass implements DataService {
 };
 
 export const kmcService: DataService = new ServiceClass(KMC_PATH);
-export const mtService: DataService = new ServiceClass(MT_PATH);
+export const ctService: DataService = new ServiceClass(CT_PATH);

--- a/shared/status-source.ts
+++ b/shared/status-source.ts
@@ -16,7 +16,7 @@ export enum StatusSource {
   LaunchPadBeta = "launch-pad-beta",
   LaunchPadStable = "launch-pad-stable",
   NpmKeymanCompiler = "npm-kmc",
-  NpmModelsTypes = "npm-models-types",
+  NpmCommonTypes = "npm-common-types",
   SKeymanCom = "s-keyman-com",
   PackagesSilOrg = "packages-sil-org",
   LinuxLsdevSilOrgAlpha = "linux-lsdev-sil-org-alpha",


### PR DESCRIPTION
npm package @keymanapp/models-types is obsolete, check instead @keymanapp/common-types.