### PR TITLE
feat: add support for `Test-bot:` trailer in PR comments

### DIFF
--- a/server/test/manual-test-parser.spec.ts
+++ b/server/test/manual-test-parser.spec.ts
@@ -73,8 +73,8 @@ const retestComment = `@keymanapp-test-bot retest test_foo, test_baz`;
 const retestAllComment = `
 I'm not happy with the results
 
-@keymanapp-test-bot retest all
-`;
+Test-bot: retest all
+`;  // using Test-bot: form for one example only
 const altRetestComment = `x
 @keymanapp-test-bot retest`;
 
@@ -103,7 +103,7 @@ const userTestResultsComment =
 <details><summary>Retesting Template</summary>
 
 \`\`\`
-@keymanapp-test-bot retest TEST_BAR
+Test-bot: retest TEST_BAR
 \`\`\`
 </details>`;
 
@@ -262,7 +262,7 @@ describe('ManualTestParser', function() {
   });
 
   describe('isTestControlComment()', function() {
-    it('should return true when comment contains a bot handle @keymanapp-test-bot', function() {
+    it('should return true when comment contains a bot handle "@keymanapp-test-bot" or trailer "Test-Bot:"', function() {
       let mtp = new ManualTestParser();
       assert.strictEqual(mtp.isControlComment(retestAllComment, userLogin), true);
       assert.strictEqual(mtp.isControlComment(retestComment, userLogin), true);

--- a/shared/manual-test/manual-test-parser.ts
+++ b/shared/manual-test/manual-test-parser.ts
@@ -7,9 +7,9 @@
 import { ManualTestStatusUtil, ManualTest, ManualTestProtocol, ManualTestStatus, ManualTestRun, ManualTestSuite, ManualTestGroup, ManualTestUtil } from './manual-test-protocols';
 
 export default class ManualTestParser {
-  controlRegex = /@keymanapp-test-bot\b/i;
-  controlRetestRegex = /@keymanapp-test-bot(?: +)retest(?: *)(.*)$/im;
-  controlSkipRegex = /@keymanapp-test-bot(?: +)skip\b/im;
+  controlRegex = /(?:@keymanapp-test-bot\b|^Test-Bot: )/im;
+  controlRetestRegex = /(?:@keymanapp-test-bot|^Test-Bot:)(?: +)retest(?: *)(.*)$/im;
+  controlSkipRegex = /(?:@keymanapp-test-bot|^Test-Bot:)(?: +)skip\b/im;
   testBotLogin = 'keymanapp-test-bot[bot]';
 
   isUserTestingComment(comment: string, login: string): boolean {
@@ -395,7 +395,7 @@ export default class ManualTestParser {
       content +=
         "<details><summary>Retesting Template</summary>\n\n" +
         "```\n" +
-        `@keymanapp-test-bot retest ${resultsTemplate.retest.trim()}\n`+
+        `Test-bot: retest ${resultsTemplate.retest.trim()}\n`+
         "```\n"+
         "</details>\n";
     }


### PR DESCRIPTION
The existing `@keymanapp-test-bot` pattern will continue to be supported, but the commit-trailer style `Test-bot: ` matches other controls we use in commit messages and is recommended for use.

Note that this trailer is only recognized in PR comments at this time; parsing commit messages may be supported in a future update (but with caution because they are less visible in the PR view and workflow, so may cause confusion to testers).

Fixes: keymanapp/keyman#13212