### PR TITLE
fix: probot api surface change with update

### DIFF
--- a/server/code.ts
+++ b/server/code.ts
@@ -345,7 +345,7 @@ app.post('/webhook/discourse', (request, response) => {
   response.send('ok');
 });
 
-app.use('/webhook/keymanapp-test-bot', keymanAppTestBotMiddleware as any);
+app.use('/webhook/keymanapp-test-bot', keymanAppTestBotMiddleware);
 
 function sendWsAlert(hasChanged: boolean, message: string): boolean {
   if(hasChanged) {

--- a/server/keymanapp-test-bot/keymanapp-test-bot-middleware.ts
+++ b/server/keymanapp-test-bot/keymanapp-test-bot-middleware.ts
@@ -43,5 +43,13 @@ const probot = new Probot({
   secret: secret,
 });
 
-const exports = createNodeMiddleware(keymanappTestBot.default, { probot });
-export default exports;
+const middleware = createNodeMiddleware(keymanappTestBot.default, { probot,
+  webhooksPath: "/",
+});
+
+export default (req, res) => {
+  middleware(req, res, () => {
+    res.writeHead(404);
+    res.end();
+  });
+};


### PR DESCRIPTION
When we updated probot from 12.3.3 to 13.4.5, it looks like its API changed, which I have now located in the release notes at https://github.com/probot/probot/releases/tag/v13.0.0.

This seems to be the new API req.

Fixes: #513