### PR TITLE
feat: diff-based refresh of GitHub issues

### DIFF
--- a/server/services/github/github-issue.ts
+++ b/server/services/github/github-issue.ts
@@ -1,0 +1,213 @@
+/*
+ * Keyman is copyright (C) SIL Global. MIT License.
+ *
+ * Created by mcdurdin on 2025-08-17
+ *
+ * Returns a single issue in the same format as github-issues
+ */
+
+import httppost from '../../util/httppost.js';
+import { github_token } from '../../identity/github.js';
+import { logGitHubRateLimit } from '../../util/github-rate-limit.js';
+
+export interface KSGitHubIssue {
+  repository: { name: string },
+  state: string,
+  assignees: { nodes: { login: string, avatarUrl: string, url: string }[] },
+  author: { login: string, avatarUrl: string, url: string },
+  title: string,
+  number: number,
+  url: string,
+  labels: { nodes: { color: string, name: string }[] },
+  timelineItems: { nodes: { __typename: string, willCloseTarget: boolean, subject: { number: number, url: string } }[] },
+  milestone: { title: string },
+};
+
+export default {
+  get: function(repo: string, issueNumber: number): Promise<KSGitHubIssue | null> {
+    const ghIssueQuery = this.queryString(repo, issueNumber);
+    return httppost('api.github.com', '/graphql',  //4
+      {
+        Authorization: ` Bearer ${github_token}`,
+        Accept: 'application/vnd.github.antiope-preview+json, application/vnd.github.shadow-cat-preview+json'
+      },
+
+      // Returns single issue from a Keyman repo
+      JSON.stringify({query: ghIssueQuery})
+    ).then(data => {
+      let obj = JSON.parse(data);
+
+      logGitHubRateLimit(obj?.data?.rateLimit, 'github-issue');
+      const issue = obj?.data?.repository?.issue ?? null;
+      if(!issue) {
+        console.dir(obj);
+        console.error(`Failed to retrieve issue keymanapp/${repo}#${issueNumber}:`);
+      }
+      return issue;
+    });
+  },
+
+  queryString: function(repo, issueNumber) {
+    repo = JSON.stringify(repo);
+    return `
+    {
+      repository(owner: "keymanapp", name: ${repo}) {
+        issue(number: ${issueNumber}) {
+          repository {
+            name
+          }
+          state
+          assignees(first: 10) {
+            nodes {
+              login
+              avatarUrl
+              url
+            }
+          }
+          author {
+            login
+            avatarUrl
+            url
+          }
+          title
+          number
+          url
+          labels(first: 20) {
+            nodes {
+              color
+              name
+            }
+          }
+          timelineItems(
+            itemTypes: [CROSS_REFERENCED_EVENT, CONNECTED_EVENT, DISCONNECTED_EVENT]
+            first: 10
+          ) {
+            nodes {
+              ... on CrossReferencedEvent {
+                __typename
+                willCloseTarget
+                subject: source {
+                  ... on PullRequest {
+                    number
+                    url
+                  }
+                  ... on Issue {
+                    number
+                    url
+                  }
+                }
+              }
+              ... on ConnectedEvent {
+                __typename
+                subject {
+                  ... on PullRequest {
+                    number
+                    url
+                  }
+                }
+              }
+              ... on DisconnectedEvent {
+                __typename
+                subject {
+                  ... on PullRequest {
+                    number
+                  }
+                }
+              }
+            }
+          }
+          milestone {
+            title
+          }
+        }
+      }
+      rateLimit {
+        limit
+        cost
+        remaining
+        resetAt
+      }
+    }
+    `;
+  }
+};
+
+/*
+
+Example return:
+
+{
+  "data": {
+    "repository": {
+      "issue": {
+        "repository": {
+          "name": "keyman"
+        },
+        "assignees": {
+          "nodes": [
+            {
+              "login": "mcdurdin",
+              "avatarUrl": "https://avatars.githubusercontent.com/u/4498365?v=4",
+              "url": "https://github.com/mcdurdin"
+            }
+          ]
+        },
+        "author": {
+          "login": "mcdurdin",
+          "avatarUrl": "https://avatars.githubusercontent.com/u/4498365?v=4",
+          "url": "https://github.com/mcdurdin"
+        },
+        "title": "chore(developer): remove support for compile targets",
+        "number": 12688,
+        "url": "https://github.com/keymanapp/keyman/issues/12688",
+        "labels": {
+          "nodes": [
+            {
+              "color": "f9d0c4",
+              "name": "developer/"
+            },
+            {
+              "color": "eaa15d",
+              "name": "chore"
+            },
+            {
+              "color": "801392",
+              "name": "m:kmn"
+            }
+          ]
+        },
+        "timelineItems": {
+          "nodes": [
+            {
+              "__typename": "CrossReferencedEvent",
+              "willCloseTarget": false,
+              "subject": {
+                "number": 13349,
+                "url": "https://github.com/keymanapp/keyman/issues/13349"
+              }
+            },
+            {
+              "__typename": "CrossReferencedEvent",
+              "willCloseTarget": false,
+              "subject": {
+                "number": 2077,
+                "url": "https://github.com/keymanapp/help.keyman.com/pull/2077"
+              }
+            }
+          ]
+        },
+        "milestone": {
+          "title": "19.0"
+        }
+      }
+    },
+    "rateLimit": {
+      "limit": 5000,
+      "cost": 1,
+      "remaining": 4983,
+      "resetAt": "2025-08-17T06:15:31Z"
+    }
+  }
+}
+
+*/

--- a/server/services/github/github-issues.ts
+++ b/server/services/github/github-issues.ts
@@ -2,11 +2,12 @@
 import httppost from '../../util/httppost.js';
 import { github_token } from '../../identity/github.js';
 import { logGitHubRateLimit } from '../../util/github-rate-limit.js';
+import { KSGitHubIssue } from './github-issue.js';
 // import { getCurrentSprint } from '../../current-sprint.js';
 
 export default {
 
-  get: function(cursor, issues): Promise<Array<any>> {
+  get: function(cursor, issues): Promise<Array<KSGitHubIssue[]>> {
     const ghIssuesQuery = this.queryString(cursor);
     return httppost('api.github.com', '/graphql',  //4
       {
@@ -45,7 +46,7 @@ export default {
             repository {
               name
             }
-
+            state
             assignees(first:10) {
               nodes {
                 login

--- a/server/services/github/github-status.ts
+++ b/server/services/github/github-status.ts
@@ -372,10 +372,4 @@ export default {
       }
     });
   },
-  queryString: function() {
-    return `
-
-  `
-  }
-
 };

--- a/server/services/github/github-test-contributions.ts
+++ b/server/services/github/github-test-contributions.ts
@@ -3,6 +3,8 @@ import httppost from '../../util/httppost.js';
 import { github_token } from '../../identity/github.js';
 import { logGitHubRateLimit } from '../../util/github-rate-limit.js';
 
+export const USER_TEST_RESULT_REGEX = /^[\*\s-]*TEST_[A-Z0-9_]+[\*\s:\(]*(PASS|PASSED|FAIL|FAILED|BLOCKED|OPEN)/gm;
+
 export default {
 
   get: function(cursor, issues, startDate, user): Promise<Array<any>> {
@@ -39,7 +41,7 @@ export default {
   filterTestResults: function(results) {
     // Only return comments that have valid TEST_XXX results
     return results.filter(result => {
-      return (result.body ?? '').match(/^[\*\s-]*TEST_[A-Z0-9_]+[\*\s:\(]*(PASS|PASSED|FAIL|FAILED|BLOCKED|OPEN)/gm)
+      return (result.body ?? '').match(USER_TEST_RESULT_REGEX)
     }).map(result => { return {
         // strip body from results
         occurredAt: result.createdAt,

--- a/server/util/github-rate-limit.ts
+++ b/server/util/github-rate-limit.ts
@@ -1,3 +1,11 @@
-export function logGitHubRateLimit(rateLimit, module) {
+
+export interface KSGitHubRateLimit {
+  limit: number,
+  cost: number,
+  remaining: number,
+  resetAt: string,
+};
+
+export function logGitHubRateLimit(rateLimit: KSGitHubRateLimit, module: string) {
   console.log(`[RATE LIMIT] ${module}: cost=${rateLimit?.cost} remaining=${rateLimit?.remaining}`);
 }

--- a/shared/issue-labels.ts
+++ b/shared/issue-labels.ts
@@ -9,3 +9,8 @@ export const issueLabelTypes = [
 ];
 
 export const issueValidTitleRegex = /^(auto|bug|change|chore|docs|feat|maint|refactor|spec|style|test)(?:\(([a-z, ]+)\))?:/;
+
+// history: PRs use 'fix', but issues use 'bug'
+export const prLabelTypes = [
+  'auto', 'change', 'chore', 'docs', 'feat', 'fix', 'maint', 'refactor', 'spec', 'style', 'test'
+];


### PR DESCRIPTION
The most costly data load for status.keyman.com is the loading of open issues, which takes upwards of 30 seconds. The current design was reloading the entire issue list for every single issues, issue_comment, pull_request, check_run, or check_suite webhook event -- which is incredibly wasteful.

This change uses the webhook event type and body content to determine which data needs to be reloaded, which firstly avoids issues being reloaded constantly for unrelated events, and then secondly, does a targeted load of just the impacted issue for issues and issue_comment events, adding, replacing, or deleting just that issue from the cache.

The data sent through to clients is still a full set, not just the change, but this can come later, as it doesn't impact our rate limit on GitHub.

As a secondary improvement, issue_comment events now only trigger a reload of user test contribution data if the affected comment contains a valid user test pattern (note that if a comment edit _removes_ a valid user test pattern form the comment, the issue will remain in contributions, but this is a rare thing and not worth stressing over at this point).

We should be able to do similar things in the future for other costly GitHub data, but the issue list was the most costly, by far, of all the events. We are pushing the boundaries in the honking big request in github-status.ts, so it would be good to break this down and then apply similar principles -- probably, merging all pull request data into a single array in the cache (it has evolved and there are multiple sources of the PR data in the cache right now), then applying the same principles as I did with issues in this commit.

Test-bot: skip