### PR TITLE
feat: add Service State view

### DIFF
--- a/public/src/app/app.module.ts
+++ b/public/src/app/app.module.ts
@@ -36,6 +36,7 @@ import { CommunityQueueComponent } from "./community-queue/community-queue.compo
 import { AssignedIssuesComponent } from "./assigned-issues/assigned-issues.component";
 import { OverviewTabComponent } from "./overview-tab/overview-tab.component";
 import { createErrorHandler } from "@sentry/angular";
+import { ServiceStatePopupComponent } from "./service-state-popup/service-state-popup.component";
 
 @NgModule({
   declarations: [
@@ -67,6 +68,7 @@ import { createErrorHandler } from "@sentry/angular";
     CommunityQueueComponent,
     AssignedIssuesComponent,
     OverviewTabComponent,
+    ServiceStatePopupComponent,
   ],
   bootstrap: [AppComponent],
   imports: [

--- a/public/src/app/contributions-home/contributions-home.component.ts
+++ b/public/src/app/contributions-home/contributions-home.component.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { StatusSource } from '../../../../shared/status-source';
+import { ServiceIdentifier } from '../../../../shared/services';
 import { Status, EMPTY_STATUS } from '../status/status.interface';
 import { StatusService } from '../status/status.service';
 
@@ -33,8 +33,8 @@ export class ContributionsHomeComponent implements OnInit {
         this.sprint = queryParams.get('sprint');
       });
 
-    this.statusService.getStatus(StatusSource.GitHubMilestones).subscribe((data:any) => {
-      console.log('getStatus.data for '+StatusSource.GitHubMilestones);
+    this.statusService.getStatus(ServiceIdentifier.GitHubMilestones).subscribe((data:any) => {
+      console.log('getStatus.data for '+ServiceIdentifier.GitHubMilestones);
       this.milestones = data.milestones;
 
       this.milestone = this.milestones.find(m => m.title == this.sprint);
@@ -57,23 +57,23 @@ export class ContributionsHomeComponent implements OnInit {
             };
         }
 
-        this.refreshStatus(StatusSource.GitHubContributions);
-        this.refreshStatus(StatusSource.CommunitySite);
+        this.refreshStatus(ServiceIdentifier.GitHubContributions);
+        this.refreshStatus(ServiceIdentifier.CommunitySite);
       }
     });
   }
 
-  refreshStatus(source: StatusSource) {
+  refreshStatus(source: ServiceIdentifier) {
     this.statusService.getStatus(source, this.sprint, this.sprintStartDate)
       .subscribe(
         (data: any) => {
           console.log('getStatus.data for '+source);
           this.status.currentSprint = data.currentSprint;
           switch(source) {
-            case StatusSource.GitHubContributions:
+            case ServiceIdentifier.GitHubContributions:
               this.status.contributions = data.contributions;
               break;
-            case StatusSource.CommunitySite:
+            case ServiceIdentifier.CommunitySite:
               this.status.communitySite = this.transformCommunitySiteData(data.contributions);
               break;
           }

--- a/public/src/app/deploy-box/deploy-box.component.ts
+++ b/public/src/app/deploy-box/deploy-box.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, OnChanges, Input } from '@angular/core';
-import { StatusSource } from '../../../../shared/status-source';
+import { ServiceIdentifier } from '../../../../shared/services';
 import { compare as versionCompare } from "compare-versions";
 import { PopupComponent } from '../popup/popup.component';
 
@@ -66,12 +66,12 @@ export class DeployBoxComponent extends PopupComponent implements OnInit, OnChan
           this.targets.push({
             name: 'Play Store (Keyman)',
             url: 'https://play.google.com/store/apps/details?id=com.tavultesoft.kmapro',
-            version: this.status?.deployment?.[StatusSource.PlayStoreKeyman]?.version
+            version: this.status?.deployment?.[ServiceIdentifier.PlayStoreKeyman]?.version
           });
           this.targets.push({
             name: 'Play Store (FirstVoices)',
             url: 'https://play.google.com/store/apps/details?id=com.firstvoices.keyboards',
-            version: this.status?.deployment?.[StatusSource.PlayStoreFirstVoices]?.version
+            version: this.status?.deployment?.[ServiceIdentifier.PlayStoreFirstVoices]?.version
           });
         }
         break;
@@ -80,14 +80,14 @@ export class DeployBoxComponent extends PopupComponent implements OnInit, OnChan
           this.targets.push({
             name: 'App Store (Keyman)',
             url: 'https://itunes.apple.com/us/app/keyman/id933676545?ls=1&mt=8',
-            version: this.status?.deployment?.[StatusSource.ITunesKeyman]?.version,
-            date: this.status?.deployment?.[StatusSource.ITunesKeyman]?.releaseDate?.substr(0,10)
+            version: this.status?.deployment?.[ServiceIdentifier.ITunesKeyman]?.version,
+            date: this.status?.deployment?.[ServiceIdentifier.ITunesKeyman]?.releaseDate?.substr(0,10)
           });
           this.targets.push({
             name: 'App Store (FirstVoices)',
             url: 'https://apps.apple.com/us/app/firstvoices-keyboards/id1066651145',
-            version: this.status?.deployment?.[StatusSource.ITunesFirstVoices]?.version,
-            date: this.status?.deployment?.[StatusSource.ITunesFirstVoices]?.releaseDate?.substr(0,10)
+            version: this.status?.deployment?.[ServiceIdentifier.ITunesFirstVoices]?.version,
+            date: this.status?.deployment?.[ServiceIdentifier.ITunesFirstVoices]?.releaseDate?.substr(0,10)
           });
         }
         this.targets.push({
@@ -108,20 +108,20 @@ export class DeployBoxComponent extends PopupComponent implements OnInit, OnChan
           this.targets.push({
             name: 'Launchpad',
             url: 'https://launchpad.net/~keymanapp/+archive/ubuntu/keyman',
-            version: this.status?.deployment?.[StatusSource.LaunchPadStable]?.version,
-            date: this.status?.deployment?.[StatusSource.LaunchPadStable]?.date_published.substr(0, 10)
+            version: this.status?.deployment?.[ServiceIdentifier.LaunchPadStable]?.version,
+            date: this.status?.deployment?.[ServiceIdentifier.LaunchPadStable]?.date_published.substr(0, 10)
           }, {
             name: 'packages.sil.org',
             url: 'https://packages.sil.org/ubuntu/?prefix=ubuntu/pool/main/k/keyman/',
-            version: this.status?.deployment?.[StatusSource.PackagesSilOrg]?.version
+            version: this.status?.deployment?.[ServiceIdentifier.PackagesSilOrg]?.version
           }, {
             name: 'linux.lsdev.sil.org',
             url: '',  // Disabled, see #250 url: 'http://linux.lsdev.sil.org/ubuntu/pool/main/k/keyman/',
-            version: this.status?.deployment?.[StatusSource.LinuxLsdevSilOrgStable]?.version
+            version: this.status?.deployment?.[ServiceIdentifier.LinuxLsdevSilOrgStable]?.version
           }, {
             name: 'Debian Unstable',
             url: `https://tracker.debian.org/pkg/keyman`,
-            version: this.status?.deployment?.[StatusSource.DebianStable]?.version,
+            version: this.status?.deployment?.[ServiceIdentifier.DebianStable]?.version,
           });
         } else if (this.tier == 'beta' || this.tier == 'alpha') {
           this.targets.push({
@@ -138,7 +138,7 @@ export class DeployBoxComponent extends PopupComponent implements OnInit, OnChan
             this.targets.push({
               name: 'Debian Unstable',
               url: `https://tracker.debian.org/pkg/keyman`,
-              version: this.status?.deployment?.[StatusSource.DebianBeta]?.version,
+              version: this.status?.deployment?.[ServiceIdentifier.DebianBeta]?.version,
             });
           }
         }
@@ -158,24 +158,24 @@ export class DeployBoxComponent extends PopupComponent implements OnInit, OnChan
         this.targets.push({
           name: '@keymanapp/kmc',
           url: 'https://npmjs.com/package/@keymanapp/kmc',
-          version: this.status?.deployment?.[StatusSource.NpmKeymanCompiler]?.[this.tier]?.split('-')[0]
+          version: this.status?.deployment?.[ServiceIdentifier.NpmKeymanCompiler]?.[this.tier]?.split('-')[0]
         }, {
           name: '@keymanapp/common-types',
           url: 'https://npmjs.com/package/@keymanapp/common-types',
-          version: this.status?.deployment?.[StatusSource.NpmCommonTypes]?.[this.tier]?.split('-')[0]
+          version: this.status?.deployment?.[ServiceIdentifier.NpmCommonTypes]?.[this.tier]?.split('-')[0]
         });
         break;
     }
   }
 
   getLatestKeymanWebFromSKeymanCom(version: string) {
-    if(!this.status || !this.status.deployment || !this.status.deployment[StatusSource.SKeymanCom])
+    if(!this.status || !this.status.deployment || !this.status.deployment[ServiceIdentifier.SKeymanCom])
       return null;
 
     const web = this.platform;
     if(!web || !version.match(/^\d+\.\d+\.\d+$/))
       return null;
-    const versions: string[] = this.status.deployment[StatusSource.SKeymanCom].versions;
+    const versions: string[] = this.status.deployment[ServiceIdentifier.SKeymanCom].versions;
     if(!versions)
       return null;
 

--- a/public/src/app/home/home.component.html
+++ b/public/src/app/home/home.component.html
@@ -3,7 +3,7 @@
       <div class="container-fluid">
           <div class="navbar-header">
             <span class="navbar-brand">
-              <a href="javascript:void(0)" (click)="selectTab('overview')" title="Display overview">{{title}}</a>
+              <app-service-state-popup [serviceState]="serviceState"></app-service-state-popup>
             </span>
             <span class="navbar-phase">
               <a target='_blank' href='https://github.com/keymanapp/keyman/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+milestone%3A{{phase?.title}}+org%3Akeymanapp'>{{phase?.title}}</a>

--- a/public/src/app/service-state-popup/service-state-popup.component.css
+++ b/public/src/app/service-state-popup/service-state-popup.component.css
@@ -1,0 +1,95 @@
+/*
+ * Keyman is copyright (C) SIL Global. MIT License.
+ */
+
+.status-title {
+  cursor: pointer;
+}
+
+.service-state {
+  position: relative;
+}
+
+.service-state-popup {
+  display: block;
+  position: absolute;
+  margin: 29px 4px 24px 4px;
+  text-align: left;
+  z-index: 10;
+  background: #fcfffc;
+  color: black;
+  border: solid 1px #4c4c30;
+  padding: 0;
+  width: max-content;
+  max-width: 720px;
+  font-size: 10pt;
+
+  visibility: hidden;
+  opacity: 0;
+  transition: visibility 0s, opacity 0.15s linear;
+  transition-delay: 0.25s;
+}
+
+.gravity-top.service-state-popup {
+  border-radius: 4px 4px 0 0;
+  box-shadow: 2px 2px 4px rgba(0,0,0,0.5);
+}
+
+.gravity-bottom.service-state-popup {
+  border-radius: 0 0 4px 4px;
+  box-shadow: 2px 2px 4px rgba(0,0,0,0.5);
+}
+
+.service-state:hover > .service-state-popup,
+.service-state > .service-state-popup.pinned {
+  visibility: visible;
+  opacity: 1;
+}
+
+/* Pin */
+
+.pinned .pin {
+  background: #60a060;
+  border-radius: 6px;
+}
+
+.pin:hover {
+  background: #c0e0c0;
+}
+
+.pin {
+  cursor: pointer;
+  margin-right: 2px;
+  font-size: 8pt;
+}
+
+/* Internal styles */
+
+.title {
+  font-weight: bold;
+  background: #444444;
+  color: white;
+}
+
+table {
+  margin: 4px;
+  border-collapse: collapse;
+}
+
+.icon {
+  /* border: solid 1px #cccccc; */
+  line-height: 0.5em;
+  font-size: 1.4em;
+}
+
+.icon.loading {
+  color: yellow;
+}
+
+.icon.successful {
+  color: green;
+}
+
+.icon.error {
+  color: red;
+}

--- a/public/src/app/service-state-popup/service-state-popup.component.html
+++ b/public/src/app/service-state-popup/service-state-popup.component.html
@@ -1,0 +1,17 @@
+<!--
+  Keyman is copyright (C) SIL Global. MIT License.
+-->
+<span class="service-state">
+  <span class="status-title"><span class="icon {{overallStatus()}}">●</span> Keyman Status</span>
+  <div class="service-state-popup {{pinned ? 'pinned':''}} gravity-{{gravityX}} gravity-{{gravityY}}" #wrapper>
+    <div class="title"><span class="pin" (click)="pin()">📌</span> Service State - {{serviceState?.length}} services</div>
+
+    <table>
+      <tbody>
+      <tr *ngFor="let service of serviceState">
+        <td><span class="icon {{service.state}}" title="{{service.state}}">●</span> {{service.service}}</td><td>{{service.message}}</td>
+      </tr>
+      </tbody>
+    </table>
+  </div>
+</span>

--- a/public/src/app/service-state-popup/service-state-popup.component.ts
+++ b/public/src/app/service-state-popup/service-state-popup.component.ts
@@ -1,0 +1,41 @@
+/*
+ * Keyman is copyright (C) SIL Global. MIT License.
+ */
+import { Component, Input, OnInit } from '@angular/core';
+import { PopupComponent } from '../popup/popup.component';
+import { PopupCoordinatorService } from '../popup-coordinator.service';
+import { VisibilityService } from '../visibility/visibility.service';
+import { ServiceIdentifier, ServiceState } from '../../../../shared/services';
+
+@Component({
+  selector: 'app-service-state-popup',
+  templateUrl: './service-state-popup.component.html',
+  styleUrl: './service-state-popup.component.css',
+  standalone: false,
+})
+export class ServiceStatePopupComponent extends PopupComponent implements OnInit {
+  @Input() serviceState: {service: ServiceIdentifier, state: ServiceState, message?: string}[];
+
+  constructor(popupCoordinator: PopupCoordinatorService, visibilityService: VisibilityService) {
+    super(popupCoordinator, visibilityService);
+  }
+
+  ngOnInit() {
+    this.popupId = 'service-state';
+    this.gravityX = 'right';
+    this.gravityY = 'bottom';
+    super.ngOnInit();
+  }
+
+  overallStatus() {
+    let icon = 'successful';
+    for(const service of this.serviceState ?? []) {
+      if(service.state == 'error') {
+        icon = 'error';
+      } else if(service.state == 'loading' && icon == 'successful') {
+        icon = 'loading';
+      }
+    }
+    return icon;
+  }
+}

--- a/public/src/app/status/status.service.ts
+++ b/public/src/app/status/status.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { environment } from '../../environments/environment';
-import { StatusSource } from '../../../../shared/status-source';
+import { ServiceIdentifier } from '../../../../shared/services';
 
 @Injectable()
 export class StatusService {
@@ -10,7 +10,7 @@ export class StatusService {
 
   constructor(private http: HttpClient) { }
 
-  getStatus(source: StatusSource, sprint?: string, sprintStartDate?: Date) {
+  getStatus(source: ServiceIdentifier, sprint?: string, sprintStartDate?: Date) {
     const url = this.statusUrl + '/' + source;
     let params:any = {};
     if(sprint) params.sprint = sprint;

--- a/server/util/DataChangeTimingManager.ts
+++ b/server/util/DataChangeTimingManager.ts
@@ -1,5 +1,5 @@
 export class DataChangeTimingManager {
-  started: boolean[] = [];
+  started: Date[] = [];
   lastRun: Date[] = [];
   dataChangeTimeout: NodeJS.Timeout[] = [];
 
@@ -7,12 +7,10 @@ export class DataChangeTimingManager {
     if (this.started[id] || this.lastRun[id] &&
         (new Date()).valueOf() - this.lastRun[id].valueOf() < minInterval) {
 
-      //if(process.env['NODE_ENV'] != 'production') {
-        if(this.isRunning(id))
-          console.log(`DataChangeTimingManager: Data change for ${id} is still underway; waiting ${minInterval} milliseconds`);
-        else
-          console.log(`DataChangeTimingManager: Data change for ${id} is too soon; waiting ${minInterval} milliseconds`);
-      //}
+      console.log(
+        `DataChangeTimingManager: Data change for ${id} is ${this.isRunning(id) ? 'still underway' : 'too soon'} `+
+        `(started at ${(this.started[id] ?? '??').toString()}); waiting ${minInterval} milliseconds`
+      );
 
       if (this.dataChangeTimeout[id]) {
         clearTimeout(this.dataChangeTimeout[id]);
@@ -31,11 +29,12 @@ export class DataChangeTimingManager {
   };
 
   start = (id): void => {
-    this.started[id] = true;
+    this.started[id] = new Date();
+    // this.lastRun[id] = new Date();
   };
 
   finish = (id): void => {
-    this.started[id] = false;
+    this.started[id] = null;
     this.lastRun[id] = new Date();
   };
 

--- a/shared/services.ts
+++ b/shared/services.ts
@@ -1,4 +1,5 @@
-export enum StatusSource {
+export enum ServiceIdentifier {
+  // Custom sources
   Keyman = "keyman",
   GitHub = "github",
   GitHubIssues = "github-issues",
@@ -7,7 +8,7 @@ export enum StatusSource {
   SentryIssues = "sentry-issues",
   CodeOwners = "code-owners",
   SiteLiveliness = "site-liveliness",
-  // Deployment targets
+  // Deployment targets - standard sources
   ITunesKeyman = "itunes-keyman",
   ITunesFirstVoices = "itunes-firstvoices",
   PlayStoreKeyman = "play-store-keyman",
@@ -24,7 +25,21 @@ export enum StatusSource {
   LinuxLsdevSilOrgStable = "linux-lsdev-sil-org-stable",
   DebianBeta = "debian-beta",
   DebianStable = "debian-stable",
+  // Other standard sources
   CommunitySite = "community-site",
   GitHubMilestones = 'github-milestones',
 };
 
+export enum ServiceState {
+  loading = 'loading',
+  successful = 'successful',
+  error = 'error',
+  unknown = 'unknown',
+};
+
+export interface ServiceStateRecord {
+  state: ServiceState;
+  message: string;
+};
+
+export type ServiceStateCache = {[index in ServiceIdentifier]?: ServiceStateRecord};


### PR DESCRIPTION
This shows a list of all the data services that the Status Site connects to and reports on connectivity to those services. Currently there are 25 services listed.

Test-bot: skip