### PR TITLE
fix: extra logging and websocket types, and add timeout for http requests

### DIFF
--- a/server/code.ts
+++ b/server/code.ts
@@ -11,7 +11,6 @@ import { ServiceStateCache, ServiceIdentifier } from '../shared/services.js';
 import { SprintCache } from './data/sprint-cache.js';
 
 import ws from 'ws';
-// const ws = require('ws');
 import keymanAppTestBotMiddleware from './keymanapp-test-bot/keymanapp-test-bot-middleware.js';
 import * as currentSprint from './current-sprint.js';
 
@@ -191,7 +190,8 @@ setInterval(() => {
 // events that come in.
 const wsServer = new ws.Server({ noServer: true });
 wsServer.on('connection', socket => {
-  socket.on('message', message => {
+  socket.on('message', rawData => {
+    const message = rawData.toString();
     consoleLog('websocket', null, message);
     if(message == 'ping')
       socket.send('pong');
@@ -400,7 +400,7 @@ app.use('/webhook/keymanapp-test-bot', keymanAppTestBotMiddleware);
 function sendWsAlert(hasChanged: boolean, message: string): boolean {
   if(hasChanged) {
     wsServer.clients.forEach((client) => {
-      if(client.readState === wsServer.OPEN) {
+      if(client.readyState === ws.OPEN) {
         client.send(message);
       }
     });

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -30,6 +30,7 @@
         "@types/jest": "^27.0.1",
         "@types/node": "^16.7.1",
         "@types/parse-link-header": "^1.0.0",
+        "@types/ws": "^8.18.1",
         "@typescript-eslint/eslint-plugin": "^4.18.0",
         "@typescript-eslint/parser": "^4.18.0",
         "eslint": "^7.22.0",
@@ -2277,6 +2278,16 @@
       "version": "4.0.14",
       "resolved": "https://registry.npmjs.org/@types/tedious/-/tedious-4.0.14.tgz",
       "integrity": "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -9789,6 +9800,15 @@
       "version": "4.0.14",
       "resolved": "https://registry.npmjs.org/@types/tedious/-/tedious-4.0.14.tgz",
       "integrity": "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }

--- a/server/package.json
+++ b/server/package.json
@@ -34,13 +34,14 @@
     "@types/jest": "^27.0.1",
     "@types/node": "^16.7.1",
     "@types/parse-link-header": "^1.0.0",
+    "@types/ws": "^8.18.1",
     "@typescript-eslint/eslint-plugin": "^4.18.0",
     "@typescript-eslint/parser": "^4.18.0",
     "eslint": "^7.22.0",
     "mocha": "^10.2.0",
     "run-script-os": "^1.1.6",
-    "tsc-watch": "^4.2.9",
     "ts-node": "^10.9.2",
+    "tsc-watch": "^4.2.9",
     "typescript": "^5.8.3"
   }
 }

--- a/server/util/httppost.ts
+++ b/server/util/httppost.ts
@@ -1,4 +1,5 @@
 import * as https from "node:https";
+import { consoleError } from "./console-log.js";
 
 type resolver = (a: string) => void;
 
@@ -21,7 +22,7 @@ export default function httppost(hostname, path, headers, data) {
     try {
       const req = https.request(options, res => {
         if(res.statusCode != 200) {
-          console.error(`statusCode for ${hostname}${path}: ${res.statusCode} ${res.statusMessage}`);
+          consoleError('http-post', 'http-post', `statusCode for ${hostname}${path}: ${res.statusCode} ${res.statusMessage}`);
           reject(`statusCode for ${hostname}${path}: ${res.statusCode} ${res.statusMessage}`);
           return;
         }
@@ -43,7 +44,7 @@ export default function httppost(hostname, path, headers, data) {
       req.write(data);
       req.end();
     } catch(e) {
-      console.log(e);
+      consoleError('http-post', 'http-post', e);
       reject(e);
     }
   });


### PR DESCRIPTION
Trying to pinpoint where github-status is falling over after some time running in production. Currently we see a log entry for timing[github] starting but it never returns finishing (this was with a check_suite entry). No errors, just disappears into nowhere.

Test-bot: skip