### PR TITLE
change: show counters on service state

### DIFF
--- a/public/src/app/data/data.model.ts
+++ b/public/src/app/data/data.model.ts
@@ -66,7 +66,7 @@ export class DataModel {
 
   updateServiceState(data: ServiceStateCache) {
     this.serviceState = Object.keys(data).map(key =>
-      ({service: <ServiceIdentifier>key, state: data[key].state, message: data[key].message})
+      ({service: <ServiceIdentifier>key, state: data[key].state, message: data[key].message, lastStateChange: data[key].lastStateChange})
     );
   }
 

--- a/public/src/app/service-state-popup/service-state-popup.component.html
+++ b/public/src/app/service-state-popup/service-state-popup.component.html
@@ -9,7 +9,7 @@
     <table>
       <tbody>
       <tr *ngFor="let service of serviceState">
-        <td><span class="icon {{service.state}}" title="{{service.state}}">●</span> {{service.service}}</td><td>{{service.message}}</td>
+        <td><span class="icon {{service.state}}" title="{{service.state}}">●</span> {{service.service}}</td><td>{{lastChange(service)}} {{service.message}}</td>
       </tr>
       </tbody>
     </table>

--- a/server/data/status-data.ts
+++ b/server/data/status-data.ts
@@ -103,6 +103,7 @@ export class StatusData {
     if(this.cache.serviceState[service] != newState) {
       this.cache.serviceState[service] = {
         state,
+        lastStateChange: new Date().valueOf(),
         // for now, limit errors to first 100 chars, hopefully enough to get a bit of an idea
         message: message === undefined
           ? undefined

--- a/shared/services.ts
+++ b/shared/services.ts
@@ -39,6 +39,7 @@ export enum ServiceState {
 
 export interface ServiceStateRecord {
   state: ServiceState;
+  lastStateChange: number; /// msec since epoch
   message: string;
 };
 


### PR DESCRIPTION
This allows us to see how long services have been down for, or attempting to read from service etc. Service timers start showing after 5 seconds for loading state (and update each second), or 3 minutes for successful (loaded) state (and update each minute). For error or unknown states, the timer shows immediately and updates every second.

Note that this does not show when the last actual change was, because this reflects only the loading state -- so each load attempt will reset the corresponding counter. We may refresh this later for more detail.

Test-bot: skip