### PR TITLE
feat: refresh single PR on PR changes

### DIFF
--- a/public/src/app/agent-detail/agent-detail.component.ts
+++ b/public/src/app/agent-detail/agent-detail.component.ts
@@ -3,6 +3,7 @@ import { platforms, PlatformSpec } from '../../../../shared/platforms';
 import { PopupCoordinatorService } from '../popup-coordinator.service';
 import { PopupComponent } from '../popup/popup.component';
 import { VisibilityService } from '../visibility/visibility.service';
+import { Status } from '../status/status.interface';
 
 @Component({
     selector: 'app-agent-detail',
@@ -12,7 +13,7 @@ import { VisibilityService } from '../visibility/visibility.service';
 })
 export class AgentDetailComponent extends PopupComponent implements OnInit {
   @Input() agent: any;
-  @Input() status: any;
+  @Input() status: Status;
 
   platform: PlatformSpec;
   buildType: string;
@@ -45,7 +46,7 @@ export class AgentDetailComponent extends PopupComponent implements OnInit {
       }
       if(this.agent.build.branchName?.match(/^\d+$/)) {
         const prNumber = parseInt(this.agent.build.branchName, 10);
-        this.pullRequest = this.status.github?.data?.repository?.pullRequests?.edges?.find(pr => pr.node?.number == prNumber)?.node;
+        this.pullRequest = this.status.keymanRepo?.pullRequests?.edges?.find(pr => pr.node?.number == prNumber)?.node;
         if(!this.pullRequest) {
           this.pullRequest = {number: prNumber, title: '<unknown pull request>'};
         }

--- a/public/src/app/build-queue/build-queue.component.ts
+++ b/public/src/app/build-queue/build-queue.component.ts
@@ -53,7 +53,7 @@ export class BuildQueueComponent extends PopupComponent implements OnInit {
 
   getPullRequestTitle(build) {
     const prNumber = parseInt(build.branchName, 10);
-    const pullRequest = this.status.github?.data?.repository?.pullRequests?.edges?.find(pr => pr.node?.number == prNumber)?.node;
+    const pullRequest = this.status.keymanRepo?.pullRequests?.edges?.find(pr => pr.node?.number == prNumber)?.node;
     return pullRequest ? pullRequest.title : '<unknown pull request>';
   }
 

--- a/public/src/app/data/data.model.ts
+++ b/public/src/app/data/data.model.ts
@@ -86,6 +86,7 @@ export class DataModel {
         break;
       case ServiceIdentifier.GitHub:
         this.status.github = data.github;
+        this.status.keymanRepo = this.status.github?.data.organization.repositories.nodes.find(e=>e.name=='keyman');
         this.keyboardPRs = this.status.github?.data.organization.repositories.nodes.find(e=>e.name=='keyboards')?.pullRequests.edges;
         this.lexicalModelPRs = this.status.github?.data.organization.repositories.nodes.find(e=>e.name=='lexical-models')?.pullRequests.edges;
         this.transformPlatformStatusData();
@@ -181,7 +182,7 @@ export class DataModel {
     for(let platform of this.platforms) {
       platform.pulls = [];
       platform.pullsByEmoji = {};
-      for(let pull of this.status.github.data.repository.pullRequests.edges) {
+      for(let pull of this.status.keymanRepo.pullRequests.edges) {
         pull.node.checkSummary = pullChecks(pull);
         let labels = pull.node.labels.edges;
         let status = pull.node.commits.edges[0].node.commit.status;
@@ -237,8 +238,8 @@ export class DataModel {
       })
     };
 
-    if(this.status.github && this.status.github.data) {
-      this.status.github.data.repository.pullRequests.edges.forEach(item => {
+    if(this.status.keymanRepo) {
+      this.status.keymanRepo.pullRequests.edges.forEach(item => {
         removeDuplicates(item.node.timelineItems);
      });
     }
@@ -453,8 +454,8 @@ export class DataModel {
 
   extractUnlabeledPulls() {
     this.unlabeledPulls = [];
-    for(let q in this.status.github.data.repository.pullRequests.edges) {
-      let pull = this.status.github.data.repository.pullRequests.edges[q];
+    for(let q in this.status.keymanRepo.pullRequests.edges) {
+      let pull = this.status.keymanRepo.pullRequests.edges[q];
       if(!this.labeledPulls.includes(pull)) {
         this.unlabeledPulls.push({pull:pull});
       }
@@ -501,8 +502,8 @@ export class DataModel {
     this.pullsByStatus.waitingReview = [];
     this.pullsByStatus.waitingTest = [];
     this.pullsByStatus.waitingResponse = [];
-    for(let q in this.status.github.data.repository.pullRequests.edges) {
-      let pull = this.status.github.data.repository.pullRequests.edges[q];
+    for(let q in this.status.keymanRepo.pullRequests.edges) {
+      let pull = this.status.keymanRepo.pullRequests.edges[q];
       let emoji = pullEmoji(pull) || "other";
       if(!this.pullsByProject[emoji]) this.pullsByProject[emoji] = [];
 
@@ -617,7 +618,7 @@ export class DataModel {
     }
 
     while(pull && !pull.node.baseRefName.match(ultimateBaseRef)) {
-      pull = this.status.github.data.repository.pullRequests.edges.find(e => e.node.headRefName == pull.node.baseRefName);
+      pull = this.status.keymanRepo.pullRequests.edges.find(e => e.node.headRefName == pull.node.baseRefName);
     }
 
     input.node.ultimateBaseRefName = pull ? pull.node.baseRefName : 'unknown';

--- a/public/src/app/platform-tier-box/platform-tier-box.component.ts
+++ b/public/src/app/platform-tier-box/platform-tier-box.component.ts
@@ -28,9 +28,9 @@ export class PlatformTierBoxComponent implements OnInit {
   }
 
   releaseDate(platformId: string, tier: string): string {
-    if(!this.status) return '';
+    if(!this.status?.keyman?.[platformId]) return '';
     let files = this.status.keyman[platformId];
-    if(!files) return '';
+    if(!files[tier]) return '';
     files = files[tier].files;
     let items = Object.keys(files);
     if(items.length == 0) return '';

--- a/public/src/app/status/status.interface.ts
+++ b/public/src/app/status/status.interface.ts
@@ -1,6 +1,7 @@
 export interface Status {
   currentSprint: any;
   github: any;
+  keymanRepo: any;
   issues: any;
   contributions: any;
   communitySite: any;
@@ -20,6 +21,7 @@ export interface Status {
 export const EMPTY_STATUS: Status = {
   currentSprint: undefined,
   github: undefined,
+  keymanRepo: undefined,
   issues: undefined,
   contributions: undefined,
   communitySite: undefined,

--- a/server/code.ts
+++ b/server/code.ts
@@ -7,7 +7,7 @@ import * as Sentry from '@sentry/node';
 import express from 'express';
 // import * as Tracing from "@sentry/tracing";
 
-import { ServiceStateCache, ServiceIdentifier } from '../shared/services.js';
+import { ServiceStateCache, ServiceIdentifier, ServiceState } from '../shared/services.js';
 import { SprintCache } from './data/sprint-cache.js';
 
 import ws from 'ws';
@@ -132,6 +132,21 @@ const STATUS_SOURCES: ServiceIdentifier[] = [
   ServiceIdentifier.LinuxLsdevSilOrgStable
 ];
 
+// TODO: move all other services into the STATUS_SOURCES
+
+// FOR DEBUGGING
+// statusData.setServiceState(ServiceIdentifier.GitHubContributions, ServiceState.disabled);
+// statusData.setServiceState(ServiceIdentifier.SentryIssues, ServiceState.disabled);
+// statusData.setServiceState(ServiceIdentifier.TeamCity, ServiceState.disabled);
+// statusData.setServiceState(ServiceIdentifier.CodeOwners, ServiceState.disabled);
+// statusData.setServiceState(ServiceIdentifier.SiteLiveliness, ServiceState.disabled);
+// statusData.setServiceState(ServiceIdentifier.CommunitySite, ServiceState.disabled);
+// for(const id of STATUS_SOURCES) {
+//   statusData.setServiceState(id, ServiceState.disabled);
+// }
+
+///
+
 initialLoad();
 
 function initialLoad() {
@@ -222,7 +237,7 @@ async function respondGitHubDataChange(request: express.Request) {
     const pullNumber = request?.body?.pull_request?.number;
     const repo = request?.body?.repository?.name;
 
-    if((event == 'issues' || event == 'issue_comment') && !request.body.issue.pull_request) {
+    if((event == 'issues' || event == 'issue_comment') && !request?.body?.issue?.pull_request) {
       consoleLog('main', 'github', `POST webhook ${event} : keymanapp/${repo}#${issueNumber}`);
       try {
         if(await statusData.refreshGitHubIssueData(repo, issueNumber)) {
@@ -245,12 +260,24 @@ async function respondGitHubDataChange(request: express.Request) {
       const prNumber = request.body?.pull_request?.number;
   */
     } else {
-      consoleLog('main', 'github', `POST webhook ${event} : keymanapp/${repo}#${issueNumber ?? pullNumber}`);
       try {
-        const hasChanged = await statusData.refreshGitHubStatusData('current');
-        if(hasChanged) {
-          sendWsAlert(true, 'github');
+        const prNumbers: {repo: string, pullNumber: number}[] = [];
+        if(issueNumber && repo && request?.body?.issue?.pull_request) {
+          prNumbers.push({repo, pullNumber: issueNumber});
+        } else if(pullNumber && repo) {
+          prNumbers.push({repo, pullNumber});
+        } else if(event == 'check_suite') {
+          prNumbers.push(...request.body?.check_suite?.pull_requests?.map(pr => ({ repo: pr.base.repo.name, pullNumber: pr.number })) ?? []);
+        } else if(event == 'check_run') {
+          prNumbers.push(...request.body?.check_run?.check_suite?.pull_requests?.map(pr => ({ repo: pr.base.repo.name, pullNumber: pr.number })) ?? []);
         }
+
+        consoleLog('main', 'github', `POST webhook ${event} : keymanapp/${repo}#${prNumbers.map(p => `${p.repo}#${p.pullNumber}`).join(',')}`);
+
+        if(await statusData.refreshGitHubPullRequestsData(prNumbers)) {
+          sendWsAlert(true, 'github'); // TODO: later just refresh prs
+        }
+
         if(event != 'check_run' && event != 'check_suite') {
           // We'll only refresh contribution data if the event type merits it
           const isUserTestComment =

--- a/server/data/status-data.ts
+++ b/server/data/status-data.ts
@@ -7,6 +7,7 @@ import teamcityService from "../services/teamcity/teamcity.js";
 import githubStatusService from "../services/github/github-status.js";
 import githubIssuesService from "../services/github/github-issues.js";
 import githubIssueService, { KSGitHubIssue } from "../services/github/github-issue.js";
+import githubPullRequestService from "../services/github/github-pull-request.js";
 import githubContributionsService from "../services/github/github-contributions.js";
 import githubTestContributionsService from "../services/github/github-test-contributions.js";
 import sentryIssuesService from "../services/sentry/sentry-issues.js";
@@ -97,7 +98,12 @@ export class StatusData {
   //
   public onServiceStateChanged: (serviceStateCache: ServiceStateCache) => void;
 
-  private setServiceState(service: ServiceIdentifier, state: ServiceState, message?: any) {
+  public getServiceState(service: ServiceIdentifier): ServiceState {
+    if(!this.cache.serviceState) this.cache.serviceState = {};
+    return this.cache.serviceState[service]?.state ?? ServiceState.unknown;
+  }
+
+  public setServiceState(service: ServiceIdentifier, state: ServiceState, message?: any) {
     if(!this.cache.serviceState) this.cache.serviceState = {};
     const newState = { state, message };
     if(this.cache.serviceState[service] != newState) {
@@ -114,6 +120,7 @@ export class StatusData {
   }
 
   refreshKeymanVersionData = async (): Promise<boolean> => {
+    if(this.getServiceState(ServiceIdentifier.Keyman) == ServiceState.disabled) return false;
     let keymanVersion;
     this.setServiceState(ServiceIdentifier.Keyman, ServiceState.loading);
     try {
@@ -129,6 +136,7 @@ export class StatusData {
   };
 
   refreshTeamcityData = async (): Promise<boolean> => {
+    if(this.getServiceState(ServiceIdentifier.TeamCity) == ServiceState.disabled) return false;
     let data;
     this.setServiceState(ServiceIdentifier.TeamCity, ServiceState.loading);
     try {
@@ -150,9 +158,64 @@ export class StatusData {
     return result;
   };
 
+  refreshGitHubPullRequestsData = async (pulls: {repo: string, pullNumber: number}[]) => {
+    let result = false;
+    for(const pull of pulls) {
+      result = await this.refreshGitHubPullRequestData(pull.repo, pull.pullNumber) || result;
+    }
+    return result;
+  }
+
+  refreshGitHubPullRequestData = async (repo: string, number: number) => {
+    let pull;
+      // this.setServiceStatus(StatusSource.KeymanPullRequest, ServiceStatusState.loading);
+    try {
+      pull = await logAsync(`refreshGitHubPullRequestData(${repo}, ${number})`, () => githubPullRequestService.get(repo, number));
+    } catch(e) {
+      console.error(e);
+      return false;
+    }
+
+    const repository = this.cache.sprints['current']?.github?.data.organization.repositories.nodes.find(e=>e.name == repo);
+    if(!repository) {
+      console.error(`refreshGitHubPullRequestData: Unable to find ${repo}`);
+      return false;
+    }
+
+    const idx = repository.pullRequests.edges.findIndex(pr => pr.node?.number == number);
+
+    // this.setServiceStatus(StatusSource.KeymanPullRequest, ServiceStatusState.successful);
+
+    if(pull.state == 'CLOSED' && idx >= 0) {
+      // pull has been closed, remove from cache
+      repository.pullRequests.edges.splice(idx, 1);
+      return true;
+    }
+
+    if(pull.state == 'CLOSED') {
+      // pull is closed but not in cache, no need to refresh
+      return false;
+    }
+
+    if(idx < 0) {
+      // pull is not in the cache, add it
+      repository.pullRequests.edges.push({node: pull});
+      return true;
+    }
+
+    if(deepEqual(pull, repository.pullRequests.edges[idx].node)) {
+      // pull is in cache, but has no visible changes
+      return false;
+    }
+
+    // replace existing PR in cache
+    repository.pullRequests.edges[idx].node = pull;
+    return true;
+  }
+
   refreshGitHubIssueData = async (repo: string, number: number): Promise<boolean> => {
     let issue;
-      // this.setServiceStatus(StatusSource.Keyman, ServiceStatusState.loading);
+      // this.setServiceStatus(StatusSource.KeymanIssue, ServiceStatusState.loading);
     try {
       issue = await logAsync(`refreshGitHubIssueData(${repo}, ${number})`, () => githubIssueService.get(repo, number));
     } catch(e) {
@@ -161,7 +224,7 @@ export class StatusData {
 
     const idx = this.cache.issues.findIndex(i => i.number == issue.number);
 
-    // this.setServiceStatus(StatusSource.Keyman, ServiceStatusState.successful);
+    // this.setServiceStatus(StatusSource.KeymanIssue, ServiceStatusState.successful);
 
     if(issue.state == 'CLOSED' && idx >= 0) {
       // issue has been closed, remove from cache
@@ -191,6 +254,7 @@ export class StatusData {
   };
 
   refreshGitHubIssuesData = async (): Promise<boolean> => {
+    if(this.getServiceState(ServiceIdentifier.GitHubIssues) == ServiceState.disabled) return false;
     let issues;
     this.setServiceState(ServiceIdentifier.GitHubIssues, ServiceState.loading);
     try {
@@ -208,6 +272,7 @@ export class StatusData {
   // Warning: this currently returns TRUE if sprint dates have changed,
   // not if any data has changed. This is different to all the others
   refreshGitHubStatusData = async (sprintName): Promise<boolean> => {
+    if(this.getServiceState(ServiceIdentifier.GitHub) == ServiceState.disabled) return false;
     let data;
     this.setServiceState(ServiceIdentifier.GitHub, ServiceState.loading);
     try {
@@ -233,6 +298,7 @@ export class StatusData {
   };
 
   refreshGitHubContributionsData = async (sprintName: string, contributionChanges: ContributionChanges): Promise<boolean> => {
+    if(this.getServiceState(ServiceIdentifier.GitHubContributions) == ServiceState.disabled) return false;
     const sprint = this.cache.sprints[sprintName];
     if(!sprint || !sprint.phase) return false;
     this.setServiceState(ServiceIdentifier.GitHubContributions, ServiceState.loading);
@@ -263,6 +329,7 @@ export class StatusData {
   };
 
   refreshSentryIssuesData = async (): Promise<boolean> => {
+    if(this.getServiceState(ServiceIdentifier.SentryIssues) == ServiceState.disabled) return false;
     let sentryIssues;
     this.setServiceState(ServiceIdentifier.SentryIssues, ServiceState.loading);
     try {
@@ -278,6 +345,7 @@ export class StatusData {
   };
 
   refreshCodeOwnersData = async (): Promise<boolean> => {
+    if(this.getServiceState(ServiceIdentifier.CodeOwners) == ServiceState.disabled) return false;
     let codeOwners;
     this.setServiceState(ServiceIdentifier.CodeOwners, ServiceState.loading);
     try {
@@ -293,6 +361,7 @@ export class StatusData {
   };
 
   refreshSiteLivelinessData = async (): Promise<boolean> => {
+    if(this.getServiceState(ServiceIdentifier.SiteLiveliness) == ServiceState.disabled) return false;
     let siteLiveliness;
     this.setServiceState(ServiceIdentifier.SiteLiveliness, ServiceState.loading);
     try {
@@ -310,6 +379,7 @@ export class StatusData {
   // Deployment endpoints
 
   refreshService = async (id: ServiceIdentifier, service: DataService): Promise<boolean> => {
+    if(this.getServiceState(id) == ServiceState.disabled) return false;
     // console.log('[Refresh] '+id+' ENTER');
     let status;
     this.setServiceState(id, ServiceState.loading);
@@ -333,6 +403,7 @@ export class StatusData {
   // Discourse
 
   refreshCommunitySiteData = async (sprintName: string, user?: string): Promise<boolean> => {
+    if(this.getServiceState(ServiceIdentifier.CommunitySite) == ServiceState.disabled) return false;
     const sprint = this.cache.sprints[sprintName];
     if(!sprint || !sprint.phase) {
       consoleError('refresh', 'community-site', `invalid sprint ${JSON.stringify(sprint)}`);

--- a/server/keymanapp-test-bot/keymanapp-test-bot.ts
+++ b/server/keymanapp-test-bot/keymanapp-test-bot.ts
@@ -309,7 +309,7 @@ const exports = (app: Probot) => {
 
     // We can look for a corresponding PR in our cache because we'll almost certainly have it there
     // before any check returns 'success'.
-    const pulls = statusData.cache.sprints?.current?.github?.data?.repository?.pullRequests?.edges;
+    const pulls = statusData.cache.sprints?.current?.github?.data?.organization?.repositories?.nodes.find(e=>e.name=='keyman')?.pullRequests?.edges;
     if(!pulls) {
       log('status EXIT: '+context.id+' -- no pulls found -- cache may not be ready');
       return null;

--- a/server/services/github/github-pull-request.ts
+++ b/server/services/github/github-pull-request.ts
@@ -1,0 +1,70 @@
+/*
+ * Keyman is copyright (C) SIL Global. MIT License.
+ *
+ * Created by mcdurdin on 2025-08-17
+ *
+ * Returns a single pull request in the same format as github status
+ */
+
+import httppost from '../../util/httppost.js';
+import { github_token } from '../../identity/github.js';
+import { logGitHubRateLimit } from '../../util/github-rate-limit.js';
+import { pullRequestQuery } from './github-status.js';
+
+export interface KSGitHubPullRequest {
+  // TODO
+  // repository: { name: string },
+  // state: string,
+  // assignees: { nodes: { login: string, avatarUrl: string, url: string }[] },
+  // author: { login: string, avatarUrl: string, url: string },
+  // title: string,
+  // number: number,
+  // url: string,
+  // labels: { nodes: { color: string, name: string }[] },
+  // timelineItems: { nodes: { __typename: string, willCloseTarget: boolean, subject: { number: number, url: string } }[] },
+  // milestone: { title: string },
+};
+
+export default {
+  get: function(repo: string, pullNumber: number): Promise<KSGitHubPullRequest | null> {
+    const ghPullQuery = this.queryString(repo, pullNumber);
+    return httppost('api.github.com', '/graphql',  //4
+      {
+        Authorization: ` Bearer ${github_token}`,
+        Accept: 'application/vnd.github.antiope-preview+json, application/vnd.github.shadow-cat-preview+json'
+      },
+
+      // Returns single issue from a Keyman repo
+      JSON.stringify({query: ghPullQuery})
+    ).then(data => {
+      let obj = JSON.parse(data);
+
+      logGitHubRateLimit(obj?.data?.rateLimit, 'github-issue');
+      const pullRequest = obj?.data?.repository?.pullRequest ?? null;
+      if(!pullRequest) {
+        console.dir(obj);
+        console.error(`Failed to retrieve pull keymanapp/${repo}#${pullNumber}:`);
+      }
+      return pullRequest;
+    });
+  },
+
+  queryString: function(repo, pullNumber) {
+    repo = JSON.stringify(repo);
+    return `
+    {
+      repository(owner: "keymanapp", name: ${repo}) {
+        pullRequest(number: ${pullNumber}) {
+          ${pullRequestQuery}
+        }
+      }
+      rateLimit {
+        limit
+        cost
+        remaining
+        resetAt
+      }
+    }
+    `;
+  }
+};

--- a/server/services/github/github-status.ts
+++ b/server/services/github/github-status.ts
@@ -120,123 +120,6 @@ const queryStrings = {
     }
   `,
 
-  repository: `
-    rateLimit {
-      limit
-      cost
-      remaining
-      resetAt
-    }
-    repository(owner: "keymanapp", name: "keyman") {
-      pullRequests(last: 100, states: OPEN) {
-        edges {
-          node {
-            title
-            milestone {
-              title
-            }
-
-            isDraft # requires application/vnd.github.shadow-cat-preview+json
-
-            additions
-            deletions
-
-            headRefName
-            baseRefName
-
-            author {
-              avatarUrl
-              login
-              url
-            }
-
-            reviewsRequested:timelineItems(
-              itemTypes: [REVIEW_REQUESTED_EVENT]
-              first: 10
-            ) {
-              nodes {
-                ... on ReviewRequestedEvent {
-                  createdAt
-                }
-              }
-            }
-
-            timelineItems(itemTypes: [CROSS_REFERENCED_EVENT, CONNECTED_EVENT, DISCONNECTED_EVENT], first: 10) {
-              nodes {
-                ... on CrossReferencedEvent {
-                  __typename
-                  subject: source {
-                    ... on Issue {
-                      number
-                      url
-                    }
-                    ... on PullRequest {
-                      number
-                      url
-                    }
-                  }
-                }
-                ... on ConnectedEvent {
-                  __typename
-                  subject {
-                    ... on Issue {
-                      number
-                      url
-                    }
-                  }
-                }
-                ... on DisconnectedEvent {
-                  __typename
-                  subject {
-                    ... on Issue {
-                      number
-                    }
-                  }
-                }
-              }
-            }
-
-            reviews(last:100) {
-              nodes {
-                author { login }
-                updatedAt
-                state
-              }
-            }
-
-            number
-            url
-            commits(last: 1) {
-              edges {
-                node {
-                  commit {
-                    oid
-                    status {
-                      contexts {
-                        description
-                        context
-                        state
-                        targetUrl
-                      }
-                    }
-                  }
-                }
-              }
-            }
-            labels(first: 25) {
-              edges {
-                node {
-                  color
-                  name
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-   `,
-
   organization: `
     rateLimit {
       limit
@@ -254,6 +137,120 @@ const queryStrings = {
   `
 };
 
+export const pullRequestQuery = `
+  title
+  number
+  isDraft # requires application/vnd.github.shadow-cat-preview+json
+  headRefName
+  baseRefName
+
+  additions
+  deletions
+
+  milestone {
+    title
+  }
+  author {
+    avatarUrl
+    login
+    url
+  }
+
+  reviewsRequested:timelineItems(
+    itemTypes: [REVIEW_REQUESTED_EVENT]
+    first: 10
+  ) {
+    nodes {
+      ... on ReviewRequestedEvent {
+        createdAt
+      }
+    }
+  }
+
+  timelineItems(itemTypes: [CROSS_REFERENCED_EVENT, CONNECTED_EVENT, DISCONNECTED_EVENT], first: 10) {
+    nodes {
+      ... on CrossReferencedEvent {
+        __typename
+        subject: source {
+          ... on Issue {
+            number
+            url
+          }
+          ... on PullRequest {
+            number
+            url
+          }
+        }
+      }
+      ... on ConnectedEvent {
+        __typename
+        subject {
+          ... on Issue {
+            number
+            url
+          }
+        }
+      }
+      ... on DisconnectedEvent {
+        __typename
+        subject {
+          ... on Issue {
+            number
+          }
+        }
+      }
+    }
+  }
+
+  commits(last: 1) {
+    edges {
+      node {
+        commit {
+          oid
+          status {
+            contexts {
+              description
+              context
+              state
+              targetUrl
+            }
+          }
+        }
+      }
+    }
+    nodes {
+      commit {
+        checkSuites(last: 10) {
+          nodes {
+            app { name }
+            conclusion
+            status
+          }
+        }
+      }
+    }
+  }
+
+  reviews(last:100) {
+    nodes {
+      author { login }
+      updatedAt
+      state
+    }
+  }
+
+  labels(first: 25) {
+    edges {
+      node {
+        color
+        name
+      }
+    }
+  }
+
+  url
+`;
+
 const repoQuery = (name) => `
   rateLimit {
     limit
@@ -266,56 +263,8 @@ const repoQuery = (name) => `
     pullRequests(last: 100, states: OPEN) {
       edges {
         node {
-          title
-          number
-          isDraft # requires application/vnd.github.shadow-cat-preview+json
-          headRefName
-          baseRefName
+          ${pullRequestQuery}
 
-          additions
-          deletions
-
-          milestone {
-            title
-          }
-          author {
-            avatarUrl
-            login
-            url
-          }
-
-          commits(last: 1) {
-            nodes {
-              commit {
-                checkSuites(last: 10) {
-                  nodes {
-                    app { name }
-                    conclusion
-                    status
-                  }
-                }
-              }
-            }
-          }
-
-          reviews(last:100) {
-            nodes {
-              author { login }
-              updatedAt
-              state
-            }
-          }
-
-          labels(first: 25) {
-            edges {
-              node {
-                color
-                name
-              }
-            }
-          }
-
-          url
         }
       }
     }
@@ -408,7 +357,7 @@ export default {
       // }
 
       const dd: any = githubPullsData.data;
-      if(!dd?.repository) {
+      if(!dd?.organization) {
         return null;
       }
 

--- a/shared/services.ts
+++ b/shared/services.ts
@@ -35,6 +35,7 @@ export enum ServiceState {
   successful = 'successful',
   error = 'error',
   unknown = 'unknown',
+  disabled = 'disabled',
 };
 
 export interface ServiceStateRecord {


### PR DESCRIPTION
* Remove duplicate keyman repo Pull Request data loading.
* Support refreshing just a single PR on changes.
* Note that the websocket refresh is still for all github data from server to client, but we no longer retrieve the whole github-status data on every PR change -- so we significantly lighten the load for the GitHub data refresh, which should reduce errors and load limits.

Test-bot: skip