### PR TITLE
feat: automatically reload after upgrade if page requires it

### DIFF
--- a/public/src/app/home/home.component.ts
+++ b/public/src/app/home/home.component.ts
@@ -7,6 +7,7 @@ import { getTz, getUserAvatarUrl } from '../../../../shared/users';
 import { ContributionsModel } from '../data/contributions.model';
 import { appState } from '../../state';
 import { dataModel } from '../data/data.model';
+import { buildVersion } from '../../../../shared/version';
 
 @Component({
     selector: 'app-home',
@@ -68,7 +69,13 @@ export class HomeComponent {
     this.ws = new DataSocket();
     this.ws.onMessage = (data: string) => {
       this.zone.run(() => {
-        if(data.startsWith('service-state:')) {
+        if(data.startsWith('version:')) {
+          const json = JSON.parse(data.substring('version:'.length));
+          console.log(`Server version: ${json.buildVersion}; client version: ${buildVersion}`);
+          if(json.buildVersion != buildVersion) {
+            window.location.reload();
+          }
+        } else if(data.startsWith('service-state:')) {
           const json = JSON.parse(data.substring('service-state:'.length));
           this.data.updateServiceState(json);
         } else {

--- a/server/code.ts
+++ b/server/code.ts
@@ -26,6 +26,7 @@ import gitHubMilestonesService from './services/github/github-milestones.js';
 import { testUserTestComment } from './keymanapp-test-bot/test-user-test-results-comment.js';
 import { performanceLog } from './performance-log.js';
 import { consoleLog } from './util/console-log.js';
+import { buildVersion } from '../shared/version.js';
 
 sms.install();
 
@@ -211,6 +212,7 @@ wsServer.on('connection', socket => {
     if(message == 'ping')
       socket.send('pong');
   });
+  socket.send('version:' + JSON.stringify({buildVersion}));
   sendInitialRefreshMessages(socket);
 });
 

--- a/shared/version.ts
+++ b/shared/version.ts
@@ -1,0 +1,1 @@
+export const buildVersion = '1.0';


### PR DESCRIPTION
Introduce version.ts which has a protocol version. If we change anything in the public folder which requires a page reload, we'll update that version string and that will cause all active clients to reload when a redeploy happens.

Test-bot: skip