### PR TITLE
fix: handle closed pull requests

### DIFF
--- a/server/code.ts
+++ b/server/code.ts
@@ -238,9 +238,10 @@ async function respondGitHubDataChange(request: express.Request) {
     const issueNumber = request?.body?.issue?.number;
     const pullNumber = request?.body?.pull_request?.number;
     const repo = request?.body?.repository?.name;
+    const action = request?.body?.action;
 
     if((event == 'issues' || event == 'issue_comment') && !request?.body?.issue?.pull_request) {
-      consoleLog('main', 'github', `POST webhook ${event} : keymanapp/${repo}#${issueNumber}`);
+      consoleLog('main', 'github', `POST webhook ${event}.${action} : keymanapp/${repo}#${issueNumber}`);
       try {
         if(await statusData.refreshGitHubIssueData(repo, issueNumber)) {
           sendWsAlert(true, 'github-issues');
@@ -263,18 +264,18 @@ async function respondGitHubDataChange(request: express.Request) {
   */
     } else {
       try {
-        const prNumbers: {repo: string, pullNumber: number}[] = [];
+        const prNumbers: {hasBeenClosed: boolean, repo: string, pullNumber: number}[] = [];
         if(issueNumber && repo && request?.body?.issue?.pull_request) {
-          prNumbers.push({repo, pullNumber: issueNumber});
+          prNumbers.push({hasBeenClosed: false, repo, pullNumber: issueNumber});
         } else if(pullNumber && repo) {
-          prNumbers.push({repo, pullNumber});
+          prNumbers.push({hasBeenClosed: request.body.action == 'closed',  repo, pullNumber});
         } else if(event == 'check_suite') {
-          prNumbers.push(...request.body?.check_suite?.pull_requests?.map(pr => ({ repo: pr.base.repo.name, pullNumber: pr.number })) ?? []);
+          prNumbers.push(...request.body?.check_suite?.pull_requests?.map(pr => ({ hasBeenClosed: false, repo: pr.base.repo.name, pullNumber: pr.number })) ?? []);
         } else if(event == 'check_run') {
-          prNumbers.push(...request.body?.check_run?.check_suite?.pull_requests?.map(pr => ({ repo: pr.base.repo.name, pullNumber: pr.number })) ?? []);
+          prNumbers.push(...request.body?.check_run?.check_suite?.pull_requests?.map(pr => ({ hasBeenClosed: false, repo: pr.base.repo.name, pullNumber: pr.number })) ?? []);
         }
 
-        consoleLog('main', 'github', `POST webhook ${event} : ${prNumbers.map(p => `keymanapp/${p.repo}#${p.pullNumber}`).join(',')}`);
+        consoleLog('main', 'github', `POST webhook ${event}.${action} : ${prNumbers.map(p => `keymanapp/${p.repo}#${p.pullNumber}`).join(',')}`);
 
         if(await statusData.refreshGitHubPullRequestsData(prNumbers)) {
           sendWsAlert(true, 'github'); // TODO: later just refresh prs

--- a/server/data/status-data.ts
+++ b/server/data/status-data.ts
@@ -158,22 +158,24 @@ export class StatusData {
     return result;
   };
 
-  refreshGitHubPullRequestsData = async (pulls: {repo: string, pullNumber: number}[]) => {
+  refreshGitHubPullRequestsData = async (pulls: {hasBeenClosed: boolean, repo: string, pullNumber: number}[]) => {
     let result = false;
     for(const pull of pulls) {
-      result = await this.refreshGitHubPullRequestData(pull.repo, pull.pullNumber) || result;
+      result = await this.refreshGitHubPullRequestData(pull.hasBeenClosed, pull.repo, pull.pullNumber) || result;
     }
     return result;
   }
 
-  refreshGitHubPullRequestData = async (repo: string, number: number) => {
+  refreshGitHubPullRequestData = async (hasBeenClosed: boolean, repo: string, number: number) => {
     let pull;
       // this.setServiceStatus(StatusSource.KeymanPullRequest, ServiceStatusState.loading);
-    try {
-      pull = await logAsync(`refreshGitHubPullRequestData(${repo}, ${number})`, () => githubPullRequestService.get(repo, number));
-    } catch(e) {
-      console.error(e);
-      return false;
+    if(!hasBeenClosed) {
+      try {
+        pull = await logAsync(`refreshGitHubPullRequestData(${repo}, ${number})`, () => githubPullRequestService.get(repo, number));
+      } catch(e) {
+        console.error(e);
+        return false;
+      }
     }
 
     const repository = this.cache.sprints['current']?.github?.data.organization.repositories.nodes.find(e=>e.name == repo);
@@ -186,14 +188,14 @@ export class StatusData {
 
     // this.setServiceStatus(StatusSource.KeymanPullRequest, ServiceStatusState.successful);
 
-    if(pull.state == 'CLOSED' && idx >= 0) {
-      // pull has been closed, remove from cache
-      console.log(`refreshGitHubPullRequestData: Removing ${repo}#${number} from cache and announcing refresh`);
-      repository.pullRequests.edges.splice(idx, 1);
-      return true;
-    }
+    if(hasBeenClosed || pull.state == 'CLOSED') {
+      if(idx >= 0) {
+        // pull has been closed, remove from cache
+        console.log(`refreshGitHubPullRequestData: Removing ${repo}#${number} from cache and announcing refresh`);
+        repository.pullRequests.edges.splice(idx, 1);
+        return true;
+      }
 
-    if(pull.state == 'CLOSED') {
       // pull is closed but not in cache, no need to refresh
       console.log(`refreshGitHubPullRequestData: ${repo}#${number} was not found in cache`);
       return false;


### PR DESCRIPTION
When a PR is closed, avoid re-loading the data from the PR and just remove it from the cache.

Test-bot: skip