### PR TITLE
feat: automatic version update, and reload page button for new version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,29 @@
     "": {
       "name": "keyman-status",
       "version": "1.0.0",
-      "license": "MIT"
+      "license": "MIT",
+      "devDependencies": {
+        "run-script-os": "^1.1.6"
+      }
+    },
+    "node_modules/run-script-os": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/run-script-os/-/run-script-os-1.1.6.tgz",
+      "integrity": "sha512-ql6P2LzhBTTDfzKts+Qo4H94VUKpxKDFz6QxxwaUZN0mwvi7L3lpOI7BqPCq7lgDh3XLl0dpeXwfcVIitlrYrw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "run-os": "index.js",
+        "run-script-os": "index.js"
+      }
+    }
+  },
+  "dependencies": {
+    "run-script-os": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/run-script-os/-/run-script-os-1.1.6.tgz",
+      "integrity": "sha512-ql6P2LzhBTTDfzKts+Qo4H94VUKpxKDFz6QxxwaUZN0mwvi7L3lpOI7BqPCq7lgDh3XLl0dpeXwfcVIitlrYrw==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,14 +5,21 @@
   "main": "server/dist/server/code.js",
   "type": "module",
   "scripts": {
-    "build": "npm run-script build-server && npm run-script build-client",
-    "build-client": "cd public && npm install && npm run-script build",
-    "build-server": "cd server && npm install && npm run-script build",
+    "prebuild": "run-script-os",
+    "prebuild:windows": "tools\\_prebuild.bat",
+    "prebuild:default": "./tools/_prebuild.sh",
+    "postbuild": "git checkout shared/version.ts",
+    "build": "npm ci && npm run-script prebuild && npm run-script build-server && npm run-script build-client && npm run-script postbuild",
+    "build-client": "cd public && npm ci && npm run-script build",
+    "build-server": "cd server && npm ci && npm run-script build",
     "start-client": "cd public && npm run-script start",
     "start-server": "cd server && npm run-script start",
     "test": "cd server && npx mocha --import=./_mocha_register.js",
     "log": "az webapp log tail --resource-group keyman --name com-keyman-status"
   },
   "author": "Marc Durdin",
-  "license": "MIT"
+  "license": "MIT",
+  "devDependencies": {
+    "run-script-os": "^1.1.6"
+  }
 }

--- a/public/src/app/data/data.model.ts
+++ b/public/src/app/data/data.model.ts
@@ -15,6 +15,8 @@ interface OtherSites {
 export class DataModel {
   status: Status = EMPTY_STATUS;
 
+  serverBuildVersion: string = '';
+
   serviceState: {service: ServiceIdentifier, state: ServiceState, message?: string}[];
 
   platforms: PlatformSpec[] = JSON.parse(JSON.stringify(platforms)); // makes a copy of the constant platform data for this component

--- a/public/src/app/home/home.component.css
+++ b/public/src/app/home/home.component.css
@@ -14,6 +14,10 @@
   overflow-y: scroll;
 }
 
+#navbar-reload-page-link {
+  margin-left: 16px;
+}
+
 .navbar-phase {
   background: rgb(240,240,240);
   border-radius: 3px;

--- a/public/src/app/home/home.component.html
+++ b/public/src/app/home/home.component.html
@@ -4,6 +4,10 @@
       <div class="navbar-header">
         <span class="navbar-brand">
           <app-service-state-popup [serviceState]="serviceState"></app-service-state-popup>
+          @if (clientBuildVersion != data.serverBuildVersion) {
+            <a class="btn btn-sm btn-warning" id='navbar-reload-page-link' href="javascript:void(0)" (click)="reloadPage()"
+              title="A new version of status.keyman.com is available - current sha: {{clientBuildVersion}} / new sha: {{data.serverBuildVersion}}">Reload page</a>
+          }
         </span>
         <span class="navbar-phase">
           <a target='_blank' href='https://github.com/keymanapp/keyman/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+milestone%3A{{phase?.title}}+org%3Akeymanapp'>{{phase?.title}}</a>

--- a/public/src/app/home/home.component.ts
+++ b/public/src/app/home/home.component.ts
@@ -23,6 +23,7 @@ export class HomeComponent {
   title = 'Keyman Status';
 
   activeTab = 'overview';
+  clientBuildVersion = buildVersion;
 
   TIMER_INTERVAL = 60000; //msec  //TODO: make this static for dev side?
 
@@ -71,10 +72,8 @@ export class HomeComponent {
       this.zone.run(() => {
         if(data.startsWith('version:')) {
           const json = JSON.parse(data.substring('version:'.length));
-          console.log(`Server version: ${json.buildVersion}; client version: ${buildVersion}`);
-          if(json.buildVersion != buildVersion) {
-            window.location.reload();
-          }
+          this.data.serverBuildVersion = json.buildVersion;
+          console.log(`Server version: ${this.data.serverBuildVersion}; client version: ${this.clientBuildVersion}`);
         } else if(data.startsWith('service-state:')) {
           const json = JSON.parse(data.substring('service-state:'.length));
           this.data.updateServiceState(json);
@@ -88,6 +87,10 @@ export class HomeComponent {
   refreshBackend() {
     console.log('Connecting to status service for refresh');
     this.statusService.refreshBackend();
+  }
+
+  reloadPage() {
+    window.location.reload();
   }
 
   refreshStatus(source: ServiceIdentifier) {

--- a/shared/version.ts
+++ b/shared/version.ts
@@ -1,1 +1,2 @@
+// WARNING: this file is overwritten during builds (see _prebuild.bat/.sh)
 export const buildVersion = '1.0';

--- a/tools/_prebuild.bat
+++ b/tools/_prebuild.bat
@@ -1,0 +1,4 @@
+@echo off
+for /f %%i in ('git rev-parse HEAD') do set NEWVERSION=%%i
+echo "Setting build version to %NEWVERSION%"
+echo export const buildVersion = '%NEWVERSION%'; > shared\version.ts

--- a/tools/_prebuild.sh
+++ b/tools/_prebuild.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+NEWVERSION="$(git rev-parse HEAD)"
+echo "Writing version '$NEWVERSION' to version.ts"
+echo "export const buildVersion = '$NEWVERSION';" > shared/version.ts


### PR DESCRIPTION
Update shared/version.ts with current git commit hash prior to building the site for deployment.

Rather than auto-refresh, show a 'refresh page' link when the version changes, which both informs the user that there are changes to the status site, and avoids potential refresh loops.

Test-bot: skip